### PR TITLE
static mac flows were not being de-duped, causing constant diffing becau...

### DIFF
--- a/perl-lib/OESS/lib/OESS/Circuit.pm
+++ b/perl-lib/OESS/lib/OESS/Circuit.pm
@@ -814,7 +814,7 @@ else {
 
 }
     #if the number of endpoints is more than 2 and it is not interdomain
-    if(scalar(@{$self->get_endpoints()}) > 2 && $self->is_interdomain()){
+    if(scalar(@{$self->get_endpoints()}) > 2 && !$self->is_interdomain()){
         return $self->_dedup_flows(\@flows);
     }else{
         return \@flows;


### PR DESCRIPTION
...se it was expecting the same flow rule multiple times