### PR TITLE
Improvements to OESS::Notification 

### DIFF
--- a/app/notification/oess-notify.pl
+++ b/app/notification/oess-notify.pl
@@ -26,13 +26,17 @@ use strict;
 use OESS::DBus;
 use OESS::Notification;
 use Proc::Daemon;
-use Sys::Syslog qw(:standard :macros);
+use Log::Log4perl;
 use Getopt::Long;
 use Data::Dumper;
 
 #OESS Notification Daemon.
+my $log;
 
 sub connect_to_dbus {
+
+    Log::Log4perl::init_and_watch('/etc/oess/logging.conf',10);
+    $log = Log::Log4perl->get_logger("NOTIFY");
 
     my $fwdctl_dbus = OESS::DBus->new(
         service  => 'org.nddi.fwdctl',

--- a/perl-lib/OESS/lib/OESS/Notification.pm
+++ b/perl-lib/OESS/lib/OESS/Notification.pm
@@ -536,10 +536,18 @@ sub _connect_services {
 
 
 	  if(!defined($interface_id)){
-
+	      $self->{'log'}->error("Unable to find interface in DB: " . $endpoint->{'node'} . ":" . $endpoint->{'interface'});
+	      return;
 	  }
           my $interface = $db->get_interface(interface_id =>$interface_id);
+	  if(!defined($interface)){
+	      $self->{'log'}->error("unable to find an interface with ID: " . $interface_id);
+	      return;
+	  }
           my $workgroup_name = $interface->{'workgroup_name'};
+	  if(!defined($workgroup_name)){
+	      $self->{'log'}->error("No workgroup assigned to interface " . $interface->{'name'});
+	  }
           #if the creator of the circuit is the same as the owner of the
           #edge port we won't document them here, and if we already have the workgroup, skip it.
           if ($interface->{'workgroup_id'} == $details->{'workgroup_id'} || $owners->{ $interface->{'workgroup_id'} } ) {


### PR DESCRIPTION
Fixed logging in OESS::Notification and added some additional checks to verify we had the proper data, and cover cases where errors could possibly happen.  

We also know that sometimes the send method can bail and cause oess-notify to die.  We wrapped all of those calls in an eval to prevent the daemon from dying, and now it should log when that happens and the error to allow us a chance to fix!