### PR TITLE
Problems starting OESS on AL2S simulator because of slow FWDCTL startup

### DIFF
--- a/app/notification/oess-notify.pl
+++ b/app/notification/oess-notify.pl
@@ -40,7 +40,9 @@ sub connect_to_dbus {
 
     my $fwdctl_dbus = OESS::DBus->new(
         service  => 'org.nddi.fwdctl',
-        instance => '/controller1'
+        instance => '/controller1',
+        timeout => -1,
+        sleep_interval => .1
     );
 
     my $dbus = OESS::DBus->new(


### PR DESCRIPTION
There were problems start OESS on the AL2S simulator because FWDCTL was very slow to startup and start responding to events.  To fix this we moved the slow synchronization method to be called after FWDCTL started handling events.  This should fix our problems during startup