### PR TITLE
during testing we found a problem with editing circuits where it woul…

### DIFF
--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -31,11 +31,11 @@ OESS::Database - Database Interaction Module
 
 =head1 VERSION
 
-Version 1.1.6
+Version 1.1.6a
 
 =cut
 
-our $VERSION = '1.1.6';
+our $VERSION = '1.1.6a';
 
 =head1 SYNOPSIS
 
@@ -81,7 +81,7 @@ use OESS::Topology;
 use DateTime;
 use Data::Dumper;
 
-use constant VERSION => '1.1.6';
+use constant VERSION => '1.1.6a';
 use constant MAX_VLAN_TAG => 4096;
 use constant MIN_VLAN_TAG => 1;
 use constant SHARE_DIR => "/usr/share/doc/perl-OESS-" . VERSION . "/";
@@ -623,7 +623,9 @@ sub is_external_vlan_available_on_interface {
 		    return 0;
 		}
 	    }
-	}
+	}else{
+            return 0;
+        }
     }
 
     return 1;


### PR DESCRIPTION
…dn't let you reuse the endpoints vlan tags because they were already in use.  We missed a case when we did this change and it no longer preserved vlan tags unless you were doing an edit.