### PR TITLE
Hopefully the final fixes for 1.1.9

### DIFF
--- a/perl-lib/OESS/lib/OESS/Circuit.pm
+++ b/perl-lib/OESS/lib/OESS/Circuit.pm
@@ -328,6 +328,18 @@ sub _create_flows{
     $self->{'flows'}->{'endpoint'}->{'primary'} = $self->_dedup_flows($self->{'flows'}->{'endpoint'}->{'primary'});
     $self->{'flows'}->{'endpoint'}->{'backup'} = $self->_dedup_flows($self->{'flows'}->{'endpoint'}->{'backup'});
 
+    if($self->is_static_mac()){
+        #remove duplicates here...
+        $self->{'flows'}->{'static_mac_addr'}->{'path'}->{'primary'} = $self->_dedup_flows($self->{'flows'}->{'static_mac_addr'}->{'path'}->{'primary'});
+        $self->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{'primary'} = $self->_dedup_flows($self->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{'primary'});
+
+        if($self->has_backup_path()){
+            $self->{'flows'}->{'static_mac_addr'}->{'path'}->{'backup'} = $self->_dedup_flows($self->{'flows'}->{'static_mac_addr'}->{'path'}->{'backup'});
+            $self->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{'backup'} = $self->_dedup_flows($self->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{'backup'});
+        }
+    }
+
+
     if($self->{'state'} eq 'looped'){
         warn "CIRCUIT IS LOOPED!!!\n";
         if(defined($self->{'loop_node'})){
@@ -357,7 +369,7 @@ sub _generate_loop_node_flows{
         my $dpid = $self->{'dpid_lookup'}->{$node};
         foreach my $enter (@{$path_dict->{$node}}){
             
-            push(@{$self->{'flows'}{'path'}{$path}}, OESS::FlowRule->new( 
+            push(@{$self->{'flows'}->{'path'}->{$path}}, OESS::FlowRule->new( 
                      priority => 36000,
                      match => {dl_vlan => $enter->{'port_vlan'},
                                in_port => $enter->{'port'}},
@@ -374,7 +386,7 @@ sub _generate_loop_node_flows{
         next if ($endpoint->{'local'} == 0);
         my $e_dpid = $self->{'dpid_lookup'}{$endpoint->{'node'}};
         
-        push(@{$self->{'flows'}->{'endpoint'}{$path}}, 
+        push(@{$self->{'flows'}->{'endpoint'}->{$path}}, 
              OESS::FlowRule->new( 
                  priority => 36000,
                  dpid => $e_dpid,
@@ -395,15 +407,15 @@ sub _dedup_flows{
     foreach my $flow (@$flows){
         my $matched = 0;
         foreach my $de_duped_flow (@deduped){
-                if(!defined($flow) || !defined($de_duped_flow)){
-                    next;
-                }
-                if($de_duped_flow->get_dpid() != $flow->get_dpid()){
-                    next;
-                }
+            if(!defined($flow) || !defined($de_duped_flow)){
+                next;
+            }
+            if($de_duped_flow->get_dpid() != $flow->get_dpid()){
+                next;
+            }
             if($de_duped_flow->compare_match( flow_rule => $flow)){
-            $de_duped_flow->merge_actions( flow_rule => $flow);
-            $matched = 1;
+                $de_duped_flow->merge_actions( flow_rule => $flow);
+                $matched = 1;
             }
         }
         if($matched == 0){
@@ -496,7 +508,7 @@ sub _generate_static_mac_path_flows{
 	my @edges = $graph->edges_to($vert);
 
 	foreach my $edge ($graph->edges_to($vert)){
-	    $self->{'logger'}->debug("Finding link between " . $edge->[0] . " and " . $edge->[1]);
+	    #$self->{'logger'}->debug("Finding link between " . $edge->[0] . " and " . $edge->[1]);
 	    #my $link = $finder{$edge->[0]}{$edge->[1]};
             #this will process
 	    foreach my $endpoint (@{$self->{'details'}->{'endpoints'}}){
@@ -541,15 +553,17 @@ sub _generate_static_mac_path_flows{
 							    actions => [{'set_vlan_vid' => $internal_ids->{$path}{$next_hop[1]}{$interface_id}},
 									{'output' => $port}]);
 			    
-                            push(@{$self->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{$path}},$flow);
-			    
-			}
+                            if($node_ends{$vert} > 0){
+                                push(@{$self->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{$path}}, $flow);
+                            }else{
+                                push(@{$self->{'flows'}->{'static_mac_addr'}->{'path'}->{$path}},$flow);
+                            }
+                        }
 		    }
 		    
 		}else{
 		    
-		    $self->{'logger'}->debug("not a link");
-		    #endpoint must be on this node
+		    #endpoint must be on this node... but this is the path side...
 		    foreach my $in_port (@{$in_ports{$vert}}){
 
 			#if the in port matches the out port go on to next
@@ -561,7 +575,7 @@ sub _generate_static_mac_path_flows{
 			    my $flow = OESS::FlowRule->new( match => {'dl_vlan' => $in_port->{'tag'},
 								      'in_port' => $in_port->{'port_no'},
 								      'dl_dst' => OESS::Database::mac_hex2num($mac_addr->{'mac_address'})},
-							    priority =>35000,
+							    priority => 35000,
 							    dpid => $self->{'dpid_lookup'}->{$vert},
 							    actions => [{'set_vlan_vid' => $endpoint->{'tag'}},
 									{'output' => $endpoint->{'port_no'}}]);
@@ -853,7 +867,6 @@ sub get_flows{
     }
 
     if (!defined($params{'path'})){
-        
     	foreach my $flow (@{$self->{'flows'}->{'path'}->{'primary'}}){
             push(@flows,$flow);
     	}
@@ -862,12 +875,16 @@ sub get_flows{
             push(@flows,$flow);
     	}
 
-        foreach my $static_flow (@{$self->{'flows'}->{'static_mac_addr'}->{'path'}->{'primary'}}){
-            push(@static_flows,$static_flow);
-        }
-        
-        foreach my $static_flow (@{$self->{'flows'}->{'static_mac_addr'}->{'path'}->{'backup'}}){
-            push(@static_flows,$static_flow);
+        if($self->is_static_mac()){
+
+            foreach my $static_flow (@{$self->{'flows'}->{'static_mac_addr'}->{'path'}->{'primary'}}){
+                push(@flows,$static_flow);
+            }
+            
+            foreach my $static_flow (@{$self->{'flows'}->{'static_mac_addr'}->{'path'}->{'backup'}}){
+                push(@flows,$static_flow);
+            }
+
         }
 
         
@@ -876,9 +893,11 @@ sub get_flows{
             foreach my $flow (@{$self->{'flows'}->{'endpoint'}->{'primary'}}){
             	push(@flows,$flow);
             }
-            
-            foreach my $static_flow (@{$self->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{'primary'}}){
-	    	push(@static_flows,$static_flow);
+         
+            if($self->is_static_mac()){   
+                foreach my $static_flow (@{$self->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{'primary'}}){
+                    push(@flows,$static_flow);
+                }
             }
             
                        
@@ -888,10 +907,11 @@ sub get_flows{
             	push(@flows,$flow);
             }
             
-            foreach my $static_flow (@{$self->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{'backup'}}){
-                push(@static_flows,$static_flow);
+            if($self->is_static_mac()){
+                foreach my $static_flow (@{$self->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{'backup'}}){
+                    push(@flows,$static_flow);
+                }
             }
-            
 	}
         
     } else {
@@ -901,40 +921,36 @@ sub get_flows{
             return;
         }
         
-	foreach my $flow (@{$self->{'flows'}->{'path'}->{$path}}){
+	foreach my $flow (@{$self->{'flows'}->{'path'}->{'primary'}}){
             push(@flows,$flow);
         }
-        
+
+        foreach my $flow (@{$self->{'flows'}->{'path'}->{'backup'}}){
+            push(@flows,$flow);
+        }
+
 	foreach my $flow (@{$self->{'flows'}->{'endpoint'}->{$path}}){
             push(@flows,$flow);
         }
         
-	foreach my $static_flow (@{$self->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{$path}}){
-            push(@static_flows,$static_flow);
-        }
-        
-        foreach my $static_flow (@{$self->{'flows'}->{'static_mac_addr'}->{'path'}->{$path}}){
-            push(@static_flows,$static_flow);
-        }
-
-    }
-
-    #if the number of endpoints is more than 2 and it is not interdomain
-    if (scalar(@{$self->get_endpoints()}) > 2 && !$self->is_interdomain()){
-        if ($self->is_static_mac()) {
-            my $dedup_flows = $self->_dedup_flows(\@flows);
-            foreach my $static_flow (@static_flows) {
-                push(@$dedup_flows, $static_flow);
+        if($self->is_static_mac()){
+            
+            foreach my $static_flow (@{$self->{'flows'}->{'static_mac_addr'}->{'path'}->{'primary'}}){
+                push(@flows,$static_flow);
             }
-            return $dedup_flows;
+            
+            foreach my $static_flow (@{$self->{'flows'}->{'static_mac_addr'}->{'path'}->{'backup'}}){
+                push(@flows,$static_flow);
+            }
+            
+            foreach my $static_flow (@{$self->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{$path}}){
+                push(@flows,$static_flow);
+            }
         }
-	else {
-	    return $self->_dedup_flows(\@flows);
-	}
-	
-    } else {
-        return \@flows;
+
     }
+
+    return $self->_dedup_flows(\@flows);
 }
 
 =head2 get_endpoint_flows

--- a/perl-lib/OESS/lib/OESS/Circuit.pm
+++ b/perl-lib/OESS/lib/OESS/Circuit.pm
@@ -357,7 +357,6 @@ sub _generate_loop_node_flows{
 
     foreach my $node (keys %$path_dict) {
         my $node_id = $self->{'node_id_lookup'}->{$node};
-        warn "Comparing " . $node_id . " to " . $params{'node'} . "\n";
         next if $node_id != $params{'node'};
         #ok we found our node
         
@@ -376,7 +375,6 @@ sub _generate_loop_node_flows{
     }
 
     foreach my $endpoint (@{$self->{'details'}->{'endpoints'}}){
-        warn "Comparing " . $self->{'node_id_lookup'}->{$endpoint->{'node'}} . " to " . $params{'node'} . "\n";
         next if ($self->{'node_id_lookup'}->{$endpoint->{'node'}} != $params{'node'});
         next if ($endpoint->{'local'} == 0);
         my $e_dpid = $self->{'dpid_lookup'}{$endpoint->{'node'}};
@@ -553,12 +551,6 @@ sub _generate_static_mac_path_flows{
                                 #path flow
                                 push(@{$self->{'flows'}->{'static_mac_addr'}->{'path'}->{$path}},$flow);
                             }else{
-                                if($vert eq 'Node 51'){
-                                    warn "IN PORT: " . Data::Dumper::Dumper($in_port);
-                                    warn "NODE: " . $vert . "\n";
-                                    warn "ENDPOINT FLOW: \n";
-                                    warn Data::Dumper::Dumper($flow);
-                                }
                                 #this is an endpoint fow
                                 push(@{$self->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{$path}}, $flow);
                             }

--- a/perl-lib/OESS/lib/OESS/FWDCTL/Master.pm
+++ b/perl-lib/OESS/lib/OESS/FWDCTL/Master.pm
@@ -120,6 +120,7 @@ sub new {
         $config = "/etc/oess/database.xml";
     }
 
+    $db->{'logger'} = Log::Log4perl->get_logger('OESS.Database');    
     my $db = $params{'cache'}->{'db'};
     $db->reconnect();
 
@@ -133,6 +134,10 @@ sub new {
     if (! $topo) {
         $self->{'logger'}->fatal("Could not initialize topo library");
         exit(1);
+    }
+
+    foreach my $ckt (keys (%{$params{'cache'}->{'circuit'}})){
+        $params{'cache'}->{'circuit'}->{$ckt}->{'logger'} = Log::Log4perl->get_logger('OESS.Circuit');
     }
 
     $self->{'topo'} = $topo;

--- a/perl-lib/OESS/lib/OESS/FWDCTL/Master.pm
+++ b/perl-lib/OESS/lib/OESS/FWDCTL/Master.pm
@@ -113,6 +113,8 @@ sub new {
     my $self = $class->SUPER::new($service, '/controller1');
     bless $self, $class;
 
+
+    $self->{'logger'} = Log::Log4perl->get_logger('OESS.FWDCTL');
     #my $config = shift;
     if(!defined($config)){
         $config = "/etc/oess/database.xml";
@@ -141,7 +143,6 @@ sub new {
         $self->{'share_file'} = '/var/run/oess/share';
     }
 
-    $self->{'logger'} = Log::Log4perl->get_logger('OESS.FWDCTL');
     $self->{'circuit'} = {};
     $self->{'node_rules'} = {};
     $self->{'link_status'} = {};
@@ -467,20 +468,6 @@ sub _write_cache{
             push(@{$dpids{$flow->get_dpid()}{$ckt_id}{'flows'}{'endpoint'}{'backup'}},$flow->to_canonical());
         }
 
-        if(defined($ckt->{'flows'}->{'static_mac_addr'})){
-            foreach my $flow (@{$ckt->{'flows'}->{'static_mac_addr'}->{'path'}->{'primary'}}){
-                push(@{$dpids{$flow->get_dpid()}{$ckt_id}{'flows'}{'current'}},$flow->to_canonical());
-            }
-            foreach my $flow (@{$ckt->{'flows'}->{'static_mac_addr'}->{'path'}->{'backup'}}){
-                push(@{$dpids{$flow->get_dpid()}{$ckt_id}{'flows'}{'current'}},$flow->to_canonical());
-            }
-            foreach my $flow (@{$ckt->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{'primary'}}){
-                push(@{$dpids{$flow->get_dpid()}{$ckt_id}{'flows'}{'endpoint'}{'primary'}},$flow->to_canonical());
-            }
-            foreach my $flow (@{$ckt->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{'backup'}}){
-                push(@{$dpids{$flow->get_dpid()}{$ckt_id}{'flows'}{'endpoint'}{'backup'}},$flow->to_canonical());
-            }
-        }
     }
 
         

--- a/perl-lib/OESS/lib/OESS/FWDCTL/Master.pm
+++ b/perl-lib/OESS/lib/OESS/FWDCTL/Master.pm
@@ -468,11 +468,11 @@ sub _write_cache{
         }
 
         if(defined($ckt->{'flows'}->{'static_mac_addr'})){
-            foreach my $flow (@{$ckt->{'flows'}->{'static_mac_addr'}->{'primary'}}){
-                push(@{$dpids{$flow->get_dpid()}{$ckt_id}{'flows'}{'static_mac_addr'}{'primary'}},$flow->to_canonical());
+            foreach my $flow (@{$ckt->{'flows'}->{'static_mac_addr'}->{'path'}->{'primary'}}){
+                push(@{$dpids{$flow->get_dpid()}{$ckt_id}{'flows'}{'current'}},$flow->to_canonical());
             }
-            foreach my $flow (@{$ckt->{'flows'}->{'static_mac_addr'}->{'backup'}}){
-                push(@{$dpids{$flow->get_dpid()}{$ckt_id}{'flows'}{'static_mac_addr'}{'backup'}},$flow->to_canonical());
+            foreach my $flow (@{$ckt->{'flows'}->{'static_mac_addr'}->{'path'}->{'backup'}}){
+                push(@{$dpids{$flow->get_dpid()}{$ckt_id}{'flows'}{'current'}},$flow->to_canonical());
             }
             foreach my $flow (@{$ckt->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{'primary'}}){
                 push(@{$dpids{$flow->get_dpid()}{$ckt_id}{'flows'}{'endpoint'}{'primary'}},$flow->to_canonical());
@@ -480,7 +480,6 @@ sub _write_cache{
             foreach my $flow (@{$ckt->{'flows'}->{'static_mac_addr'}->{'endpoint'}->{'backup'}}){
                 push(@{$dpids{$flow->get_dpid()}{$ckt_id}{'flows'}{'endpoint'}{'backup'}},$flow->to_canonical());
             }
-
         }
     }
 

--- a/perl-lib/OESS/lib/OESS/FWDCTL/Master.pm
+++ b/perl-lib/OESS/lib/OESS/FWDCTL/Master.pm
@@ -120,8 +120,8 @@ sub new {
         $config = "/etc/oess/database.xml";
     }
 
-    $db->{'logger'} = Log::Log4perl->get_logger('OESS.Database');    
     my $db = $params{'cache'}->{'db'};
+    $db->{'logger'} = Log::Log4perl->get_logger('OESS.Database');    
     $db->reconnect();
 
     if (! $db) {

--- a/perl-lib/OESS/lib/OESS/FWDCTL/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/FWDCTL/Switch.pm
@@ -174,24 +174,6 @@ sub _update_cache{
         }
         
 
-        foreach my $obj (@{$data->{'ckts'}->{$ckt}->{'flows'}->{'static_mac_addr'}->{'primary'}}){
-            next unless($obj->{'dpid'} == $self->{'dpid'});
-            my $flow = OESS::FlowRule->new( match => $obj->{'match'},
-                                            actions => $obj->{'actions'},
-                                            dpid => $obj->{'dpid'},
-                                            priority =>$obj->{'priority'});
-            push(@{$self->{'ckts'}->{$ckt}->{'flows'}->{'static_mac_addr'}->{'primary'}},$flow);
-        }
-
-        foreach my $obj (@{$data->{'ckts'}->{$ckt}->{'flows'}->{'static_mac_addr'}->{'backup'}}){
-            next unless($obj->{'dpid'} == $self->{'dpid'});
-            my $flow = OESS::FlowRule->new( match => $obj->{'match'},
-                                            actions => $obj->{'actions'},
-                                            dpid => $obj->{'dpid'},
-                                            priority =>$obj->{'priority'});
-            push(@{$self->{'ckts'}->{$ckt}->{'flows'}->{'static_mac_addr'}->{'backup'}},$flow);
-        }
-
     }
 
     $self->{'node'} = $data->{'nodes'}->{$self->{'dpid'}};

--- a/perl-lib/OESS/lib/OESS/FlowRule.pm
+++ b/perl-lib/OESS/lib/OESS/FlowRule.pm
@@ -765,6 +765,8 @@ sub compare_match{
     
     return 0 if(!defined($other_match));
 
+    return 0 if($self->{'priority'} != $other_rule->{'priority'});
+
     foreach my $key (keys (%{$self->{'match'}})){
         return 0 if(!defined($other_match->{$key}));
         if($other_match->{$key} != $self->{'match'}->{$key}){
@@ -867,6 +869,9 @@ returns 0 on error
 sub merge_actions {
     my ( $self, %args ) = @_;
     my $other_flow      = $args{'flow_rule'};
+
+    warn "Self: " . Data::Dumper::Dumper($self);
+    warn "OTHER: " . Data::Dumper::Dumper($other_flow);
 
     # get the uniquye list of 'set actions' from our action list and the action list
     # of the flow we're merging

--- a/perl-lib/OESS/lib/OESS/FlowRule.pm
+++ b/perl-lib/OESS/lib/OESS/FlowRule.pm
@@ -870,9 +870,6 @@ sub merge_actions {
     my ( $self, %args ) = @_;
     my $other_flow      = $args{'flow_rule'};
 
-    warn "Self: " . Data::Dumper::Dumper($self);
-    warn "OTHER: " . Data::Dumper::Dumper($other_flow);
-
     # get the uniquye list of 'set actions' from our action list and the action list
     # of the flow we're merging
     my @set_action_types       = $self->_get_set_action_types( $self->get_actions() );

--- a/perl-lib/OESS/t/circuit-static_mac_addr.t
+++ b/perl-lib/OESS/t/circuit-static_mac_addr.t
@@ -36,1103 +36,388 @@ if ($ckt->get_active_path() eq "backup") {
 
 my $flows = $ckt->get_flows();
 ok(defined($flows), "Flows are defined");
-is(scalar(@$flows), 98, "The flow count matches " . scalar(@$flows));
+is(scalar(@$flows), 78, "The flow count matches " . scalar(@$flows));
 my @actual_3way_flows;
 
 foreach my $flow (@$flows){
-    if($flow->get_dpid() == 155569035008){
+    if($flow->get_dpid() == 155568969984){
         push(@actual_3way_flows, $flow);
     }
 }
+
 my @expected_3way_flows;
 
-
 push(@expected_3way_flows, OESS::FlowRule->new(
          'hard_timeout' => 0,
          'priority' => 32768,
          'actions' => [
              {
-                 'set_vlan_id' => 105
-             },
-             {
-                 'output' => '1'
-             },
-             {
-                 'set_vlan_id' => 28
-             },
-             {
-                 'output' => '98'
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'in_port' => 97
-         }
-
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 32768,
-         'actions' => [
-             {
-                 'set_vlan_id' => 101
-             },
-             {
-                 'output' => '97'
-             },
-             {
-                 'set_vlan_id' => 28
-             },
-             {
-                 'output' => '98'
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 102,
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 32768,
-         'actions' => [
-             {
-                 'set_vlan_id' => 101
-             },
-             {
-                 'output' => '97'
-             },
-             {
-                 'set_vlan_id' => 105
-             },
-             {
-                 'output' => '1'
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485683',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485684',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485685',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485683',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485684',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485685',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485173',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485173',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '28'
-             },
-             {
-                 'output' => 98
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485440',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '28'
-             },
-             {
-                 'output' => 98
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485441',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '28'
-             },
-             {
-                 'output' => 98
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 102,
-             'dl_dst' => '132129489485440',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '28'
-             },
-             {
-                 'output' => 98
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 102,
-             'dl_dst' => '132129489485441',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
+                 'set_vlan_id' => 100
              },
              {
                  'output' => 97
+             },
+             {
+                 'set_vlan_id' => 100
+             },
+             {
+                 'output' => 2
              }
          ],
          'idle_timeout' => 0,
-         'dpid' => '155569035008',
+         'dpid' => '155568969984',
          'match' => {
-             'dl_vlan' => 102,
-             'dl_dst' => '132129489485456',
+             'dl_vlan' => 100,
              'in_port' => 1
          }
-         
      ));
 
 push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
+          'hard_timeout' => 0,
+                 'priority' => 32768,
+                 'actions' => [
+                     {
+                                  'set_vlan_id' => 101
+                     },
+                     {
+                                  'output' => '1'
+                     },
+                     {
+                                  'set_vlan_id' => 100
+                     },
+                     {
+                                  'output' => '2'
+                     }
+                              ],
+                 'idle_timeout' => 0,
+                 'dpid' => '155568969984',
          'match' => {
-             'dl_vlan' => 102,
-             'dl_dst' => '132129489485457',
-             'in_port' => 1
-         }
-         
-     ));
+                              'dl_vlan' => 100,
+                              'in_port' => 97
+         }));
+
+push(@expected_3way_flows, OESS::FlowRule->new(
+'hard_timeout' => 0,
+                 'priority' => 32768,
+                 'actions' => [
+                     {
+                                  'set_vlan_id' => 101
+                     },
+                     {
+                                  'output' => '1'
+                     },
+                     {
+                                  'set_vlan_id' => 100
+                     },
+                     {
+                                  'output' => '97'
+                     }
+                              ],
+                 'idle_timeout' => 0,
+                 'dpid' => '155568969984',
+         'match' => {
+                              'dl_vlan' => 101,
+                              'in_port' => 2
+         }));
+
+push(@expected_3way_flows, OESS::FlowRule->new(
+'hard_timeout' => 0,
+                 'priority' => 35000,
+                 'actions' => [
+                     {
+                                  'set_vlan_id' => '101'
+                     },
+                     {
+                                  'output' => 1
+                     }
+                              ],
+                 'idle_timeout' => 0,
+                 'dpid' => '155568969984',
+         'match' => {
+                              'dl_vlan' => 100,
+                              'dl_dst' => '132129489485683',
+                              'in_port' => 97
+         }));
+push(@expected_3way_flows, OESS::FlowRule->new(
+'hard_timeout' => 0,
+                 'priority' => 35000,
+                 'actions' => [
+                     {
+                                  'set_vlan_id' => '101'
+                     },
+                     {
+                                  'output' => 1
+                     }
+                              ],
+                 'idle_timeout' => 0,
+                 'dpid' => '155568969984',
+         'match' => {
+                              'dl_vlan' => 100,
+                              'dl_dst' => '132129489485684',
+                              'in_port' => 97
+         }));
+push(@expected_3way_flows, OESS::FlowRule->new(
+'hard_timeout' => 0,
+                 'priority' => 35000,
+                 'actions' => [
+                     {
+                                  'set_vlan_id' => '101'
+                     },
+                     {
+                                  'output' => 1
+                     }
+                              ],
+                 'idle_timeout' => 0,
+                 'dpid' => '155568969984',
+         'match' => {
+                              'dl_vlan' => 100,
+                              'dl_dst' => '132129489485685',
+                              'in_port' => 97
+         }));
+push(@expected_3way_flows, OESS::FlowRule->new(
+'hard_timeout' => 0,
+                 'priority' => 35000,
+                 'actions' => [
+                     {
+                                  'set_vlan_id' => '101'
+                     },
+                     {
+                                  'output' => 1
+                     }
+                              ],
+                 'idle_timeout' => 0,
+                 'dpid' => '155568969984',
+         'match' => {
+                              'dl_vlan' => 101,
+                              'dl_dst' => '132129489485683',
+                              'in_port' => 2
+         }));
+push(@expected_3way_flows, OESS::FlowRule->new(
+ 'hard_timeout' => 0,
+                 'priority' => 35000,
+                 'actions' => [
+                     {
+                                  'set_vlan_id' => '101'
+                     },
+                     {
+                                  'output' => 1
+                     }
+                              ],
+                 'idle_timeout' => 0,
+                 'dpid' => '155568969984',
+         'match' => {
+                              'dl_vlan' => 101,
+                              'dl_dst' => '132129489485684',
+                              'in_port' => 2
+         }));
+
+push(@expected_3way_flows, OESS::FlowRule->new(
+'hard_timeout' => 0,
+                 'priority' => 35000,
+                 'actions' => [
+                     {
+                                  'set_vlan_id' => '101'
+                     },
+                     {
+                                  'output' => 1
+                     }
+                              ],
+                 'idle_timeout' => 0,
+                 'dpid' => '155568969984',
+         'match' => {
+                              'dl_vlan' => 101,
+                              'dl_dst' => '132129489485685',
+                              'in_port' => 2
+         }));
+
+push(@expected_3way_flows, OESS::FlowRule->new(
+'hard_timeout' => 0,
+                  'priority' => 35000,
+                  'actions' => [
+                      {
+                                   'set_vlan_id' => '101'
+                      },
+                      {
+                                   'output' => 1
+                      }
+                               ],
+                  'idle_timeout' => 0,
+                  'dpid' => '155568969984',
+         'match' => {
+                               'dl_vlan' => 100,
+                               'dl_dst' => '132129489485173',
+                               'in_port' => 97
+         }));
+
+push(@expected_3way_flows, OESS::FlowRule->new(
+'hard_timeout' => 0,
+                  'priority' => 35000,
+                  'actions' => [
+                      {
+                                   'set_vlan_id' => '101'
+                      },
+                      {
+                                   'output' => 1
+                      }
+                               ],
+                  'idle_timeout' => 0,
+                  'dpid' => '155568969984',
+         'match' => {
+                               'dl_vlan' => 101,
+                               'dl_dst' => '132129489485173',
+                               'in_port' => 2
+         }));
+
+push(@expected_3way_flows, OESS::FlowRule->new(
+'hard_timeout' => 0,
+                  'priority' => 35000,
+                  'actions' => [
+                      {
+                                   'set_vlan_id' => '100'
+                      },
+                      {
+                                   'output' => 2
+                      }
+                               ],
+                  'idle_timeout' => 0,
+                  'dpid' => '155568969984',
+         'match' => {
+                               'dl_vlan' => 100,
+                               'dl_dst' => '132129489485440',
+                               'in_port' => 1
+         }));
+push(@expected_3way_flows, OESS::FlowRule->new(
+         'hard_timeout' => 0,
+                  'priority' => 35000,
+                  'actions' => [
+                      {
+                                   'set_vlan_id' => '100'
+                      },
+                      {
+                                   'output' => 2
+                      }
+                               ],
+                  'idle_timeout' => 0,
+                  'dpid' => '155568969984',
+         'match' => {
+                               'dl_vlan' => 100,
+                               'dl_dst' => '132129489485441',
+                               'in_port' => 1
+         }));
 
 push(@expected_3way_flows, OESS::FlowRule->new(
          'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
+                  'priority' => 35000,
+                  'actions' => [
+                      {
+                                   'set_vlan_id' => '100'
+                      },
+                      {
+                                   'output' => 2
+                      }
+                               ],
+                  'idle_timeout' => 0,
+                  'dpid' => '155568969984',
          'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485456',
-             'in_port' => 98
-         }
-         
-     ));
+                               'dl_vlan' => 100,
+                               'dl_dst' => '132129489485440',
+                               'in_port' => 97
+         }));
 
 push(@expected_3way_flows, OESS::FlowRule->new(
          'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
+                  'priority' => 35000,
+                  'actions' => [
+                      {
+                                   'set_vlan_id' => '100'
+                      },
+                      {
+                                   'output' => 2
+                      }
+                               ],
+                  'idle_timeout' => 0,
+                  'dpid' => '155568969984',
          'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485457',
-             'in_port' => 98
-         }
-         
-     ));
+                               'dl_vlan' => 100,
+                               'dl_dst' => '132129489485441',
+                               'in_port' => 97
+         }));
+push(@expected_3way_flows, OESS::FlowRule->new(
+         'hard_timeout' => 0,
+                  'priority' => 35000,
+                  'actions' => [
+                      {
+                                   'set_vlan_id' => '100'
+                      },
+                      {
+                                   'output' => 97
+                      }
+                               ],
+                  'idle_timeout' => 0,
+                  'dpid' => '155568969984',
+         'match' => {
+                               'dl_vlan' => 100,
+                               'dl_dst' => '132129489485456',
+                               'in_port' => 1
+         }));
+push(@expected_3way_flows, OESS::FlowRule->new(
+         'hard_timeout' => 0,
+                  'priority' => 35000,
+                  'actions' => [
+                      {
+                                   'set_vlan_id' => '100'
+                      },
+                      {
+                                   'output' => 97
+                      }
+                               ],
+                  'idle_timeout' => 0,
+                  'dpid' => '155568969984',
+         'match' => {
+                               'dl_vlan' => 100,
+                               'dl_dst' => '132129489485457',
+                               'in_port' => 1
+         }));
+push(@expected_3way_flows, OESS::FlowRule->new(
+         'hard_timeout' => 0,
+                  'priority' => 35000,
+                  'actions' => [
+                      {
+                                   'set_vlan_id' => '100'
+                      },
+                      {
+                                   'output' => 97
+                      }
+                               ],
+                  'idle_timeout' => 0,
+                  'dpid' => '155568969984',
+         'match' => {
+                               'dl_vlan' => 101,
+                               'dl_dst' => '132129489485456',
+                               'in_port' => 2
+         }));
 
 push(@expected_3way_flows, OESS::FlowRule->new(
          'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
+                  'priority' => 35000,
+                  'actions' => [
+                      {
+                                   'set_vlan_id' => '100'
+                      },
+                      {
+                                   'output' => 97
+                      }
+                               ],
+                  'idle_timeout' => 0,
+                  'dpid' => '155568969984',
          'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485683',
-             'in_port' => 97
-         }
-         
-     ));
+                               'dl_vlan' => 101,
+                               'dl_dst' => '132129489485457',
+                               'in_port' => 2
+         }));
 
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485684',
-             'in_port' => 97
-         }
-         
-     ));
 
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485685',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485683',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485684',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485685',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485173',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485173',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '28'
-             },
-             {
-                 'output' => 98
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485440',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '28'
-             },
-             {
-                 'output' => 98
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485441',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '28'
-             },
-             {
-                 'output' => 98
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 102,
-             'dl_dst' => '132129489485440',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '28'
-             },
-             {
-                 'output' => 98
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 102,
-             'dl_dst' => '132129489485441',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 102,
-             'dl_dst' => '132129489485456',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 102,
-             'dl_dst' => '132129489485457',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485456',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485457',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485683',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485684',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485685',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485683',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485684',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485685',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485173',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '105'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485173',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '28'
-             },
-             {
-                 'output' => 98
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485440',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '28'
-             },
-             {
-                 'output' => 98
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485441',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '28'
-             },
-             {
-                 'output' => 98
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 102,
-             'dl_dst' => '132129489485440',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '28'
-             },
-             {
-                 'output' => 98
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 102,
-             'dl_dst' => '132129489485441',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 102,
-             'dl_dst' => '132129489485456',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 102,
-             'dl_dst' => '132129489485457',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485456',
-             'in_port' => 98
-         }
-         
-     ));
-
-push(@expected_3way_flows, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155569035008',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485457',
-             'in_port' => 98
-         }
-         
-     ));
-
+my @expected_3way_flows_backup = @expected_3way_flows;
 
 ok($#expected_3way_flows == $#actual_3way_flows ,"expected 3way flows match actual 3way flows");
 
@@ -1151,9 +436,6 @@ ok($ckt->get_active_path() eq 'backup', "Circuit is now on backup path");
 
 $flows = $ckt->get_flows();
 
-ok(defined($flows), "Flows are defined");
-is(scalar(@$flows), 98, "The flow count matches " . scalar(@$flows));
-
 my @actual_3way_flows_backup;
 
 foreach my $flow (@$flows){
@@ -1162,1092 +444,9 @@ foreach my $flow (@$flows){
     }
 }
 
-my @expected_3way_flows_backup;
+ok(defined($flows), "Flows are defined");
+is(scalar(@$flows), 78, "The flow count matches " . scalar(@$flows));
 
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 32768,
-         'actions' => [
-             {
-                 'set_vlan_id' => 100
-             },
-             {
-                 'output' => 97
-             },
-             {
-                 'set_vlan_id' => 100
-             },
-             {
-                 'output' => 2
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'in_port' => 1
-         }
-
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 32768,
-         'actions' => [
-             {
-                 'set_vlan_id' => 101
-             },
-             {
-                 'output' => '1'
-             },
-             {
-                 'set_vlan_id' => 100
-             },
-             {
-                 'output' => '2'
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'in_port' => 97
-         }
-
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 32768,
-         'actions' => [
-             {
-                 'set_vlan_id' => 101
-             },
-             {
-                 'output' => '1'
-             },
-             {
-                 'set_vlan_id' => 100
-             },
-             {
-                 'output' => '97'
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'in_port' => 2
-         }
-
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485683',
-             'in_port' => 97
-         }
-
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485684',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485685',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485683',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485684',
-             'in_port' => 2
-         }
-
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485685',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485173',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485173',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 2
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485440',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 2
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485441',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 2
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485440',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 2
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485441',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485456',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485457',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485456',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485457',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485683',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485684',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485685',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485683',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485684',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485685',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485173',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485173',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 2
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485440',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 2
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485441',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 2
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485440',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 2
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485441',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485456',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485457',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485456',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485457',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485683',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485684',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485685',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485683',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485684',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485685',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485173',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '101'
-             },
-             {
-                 'output' => 1
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485173',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 2
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485440',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 2
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485441',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 2
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485440',
-             'in_port' => 97
-         }
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 2
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485441',
-             'in_port' => 97
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485456',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 100,
-             'dl_dst' => '132129489485457',
-             'in_port' => 1
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485456',
-             'in_port' => 2
-         }
-         
-     ));
-
-push(@expected_3way_flows_backup, OESS::FlowRule->new(
-         'hard_timeout' => 0,
-         'priority' => 35000,
-         'actions' => [
-             {
-                 'set_vlan_id' => '100'
-             },
-             {
-                 'output' => 97
-             }
-         ],
-         'idle_timeout' => 0,
-         'dpid' => '155568969984',
-         'match' => {
-             'dl_vlan' => 101,
-             'dl_dst' => '132129489485457',
-             'in_port' => 2
-         }
-         
-     ));
 
 ok($#expected_3way_flows_backup == $#actual_3way_flows_backup ,"expected 3way backup flows match actual 3way backup flows");
 
@@ -2255,5 +454,3 @@ ok(OESSDatabaseTester::flows_match(
        actual_flows   => \@actual_3way_flows_backup,
        expected_flows => \@expected_3way_flows_backup
    ), "Backup Flows are as expected");
-
-

--- a/perl-lib/OESS/t/circuit-static_mac_addr.t
+++ b/perl-lib/OESS/t/circuit-static_mac_addr.t
@@ -36,7 +36,7 @@ if ($ckt->get_active_path() eq "backup") {
 
 my $flows = $ckt->get_flows();
 ok(defined($flows), "Flows are defined");
-is(scalar(@$flows), 78, "The flow count matches " . scalar(@$flows));
+is(scalar(@$flows), 74, "The flow count matches " . scalar(@$flows));
 my @actual_3way_flows;
 
 foreach my $flow (@$flows){
@@ -445,7 +445,7 @@ foreach my $flow (@$flows){
 }
 
 ok(defined($flows), "Flows are defined");
-is(scalar(@$flows), 78, "The flow count matches " . scalar(@$flows));
+is(scalar(@$flows), 74, "The flow count matches " . scalar(@$flows));
 
 
 ok($#expected_3way_flows_backup == $#actual_3way_flows_backup ,"expected 3way backup flows match actual 3way backup flows");

--- a/perl-lib/OESS/t/circuit-static_mac_addr_simple.t
+++ b/perl-lib/OESS/t/circuit-static_mac_addr_simple.t
@@ -33,7 +33,7 @@ ok($ckt->is_static_mac(), "Circuit is a static mac circuit");
 my $flows = $ckt->get_flows();
 
 ok(defined($flows), "Flows are defined");
-is(scalar(@$flows), 78, "The flow count matches " . scalar(@$flows));
+is(scalar(@$flows), 74, "The flow count matches " . scalar(@$flows));
 
 my $ep_flows = $ckt->get_endpoint_flows( path => 'primary');
 

--- a/perl-lib/OESS/t/circuit-static_mac_addr_simple.t
+++ b/perl-lib/OESS/t/circuit-static_mac_addr_simple.t
@@ -15,7 +15,7 @@ use OESS::Database;
 use OESS::Circuit;
 use OESSDatabaseTester;
 
-use Test::More tests => 5;
+use Test::More tests => 7;
 use Test::Deep;
 use Data::Dumper;
 use Log::Log4perl;
@@ -33,5 +33,11 @@ ok($ckt->is_static_mac(), "Circuit is a static mac circuit");
 my $flows = $ckt->get_flows();
 
 ok(defined($flows), "Flows are defined");
-is(scalar(@$flows), 98, "The flow count matches " . scalar(@$flows));
+is(scalar(@$flows), 78, "The flow count matches " . scalar(@$flows));
 
+my $ep_flows = $ckt->get_endpoint_flows( path => 'primary');
+
+is(scalar(@$ep_flows), 12, "The flow count matches " . scalar(@$ep_flows));
+
+my $b_ep_flows = $ckt->get_endpoint_flows( path => 'backup');
+is(scalar(@$b_ep_flows), 12, "The flow count matches " . scalar(@$b_ep_flows));


### PR DESCRIPTION
FWDCTL Startup still needed more cleaning. The Logger object needed to be re-initialized otherwise FWDCTL would die....

Also ISSUE=12755 related to static mac circuits improperly diffing and also on their backup path flooding instead of being static mac.  All static mac stuff should be resolved at this point!