### PR TITLE
Fixes typo and sets correct circuit_type on edits

### DIFF
--- a/app/oess_scheduler.pl
+++ b/app/oess_scheduler.pl
@@ -70,7 +70,8 @@ sub main{
 
             #edit the circuit to make it active
             my $output = $oess->edit_circuit(circuit_id     => $action->{'circuit_id'},
-                                             endpoint_mac_address_nums => $circuit_layout->{'endpoint_mac_address_num'},
+                                             static_mac     => $circuit_layout->{'static_mac'},
+                                             endpoint_mac_address_nums => $circuit_layout->{'endpoint_mac_address_nums'},
                                              mac_addresses  => $circuit_layout->{'mac_addresses'},
                                              name           => $circuit_layout->{'name'},
                                              bandwidth      => $circuit_layout->{'bandwidth'},
@@ -87,6 +88,9 @@ sub main{
                                              workgroup_id   => $action->{'workgroup_id'},
                                              description    => $ckt->{'description'}
                 );
+            if (!defined $output) {
+                syslog(LOG_WARNING, "Failed to update database to provision circuit: " . $oess->get_error());
+            }
 
             my $res;
             my $result;
@@ -188,7 +192,8 @@ sub main{
             syslog(LOG_INFO, "Circuit info: " . Dumper($circuit_layout));
 
             my $output = $oess->edit_circuit(circuit_id     => $action->{'circuit_id'},
-                                             endpoint_mac_address_nums => $circuit_layout->{'endpoint_mac_address_num'},
+                                             static_mac     => $circuit_layout->{'static_mac'},
+                                             endpoint_mac_address_nums => $circuit_layout->{'endpoint_mac_address_nums'},
                                              mac_addresses  => $circuit_layout->{'mac_addresses'},
                                              name           => $circuit_layout->{'name'},
                                              bandwidth      => $circuit_layout->{'bandwidth'},

--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -6897,15 +6897,20 @@ sub _add_event{
     my $params = shift;
 
     my $tmp;
-    $tmp->{'name'}         = $params->{'name'};
-    $tmp->{'bandwidth'}    = $params->{'bandwidth'};
-    $tmp->{'links'}        = $params->{'links'};
-    $tmp->{'backup_links'} = $params->{'backup_links'};
-    $tmp->{'nodes'}        = $params->{'nodes'};
-    $tmp->{'interfaces'}   = $params->{'interfaces'};
-    $tmp->{'tags'}         = $params->{'tags'};
-    $tmp->{'version'}      = "1.0";
-    $tmp->{'action'}       = "provision";
+    $tmp->{'name'}          = $params->{'name'};
+    $tmp->{'static_mac'}    = $params->{'static_mac'};
+    $tmp->{'endpoint_mac_address_nums'} = $params->{'endpoint_mac_address_nums'};
+    $tmp->{'mac_addresses'} = $params->{'mac_addresses'};
+    $tmp->{'bandwidth'}     = $params->{'bandwidth'};
+    $tmp->{'remove_time'}   = $params->{'remove_time'};
+    $tmp->{'restore_to_primary'} = $params->{'restore_to_primary'};
+    $tmp->{'links'}         = $params->{'links'};
+    $tmp->{'backup_links'}  = $params->{'backup_links'};
+    $tmp->{'nodes'}         = $params->{'nodes'};
+    $tmp->{'interfaces'}    = $params->{'interfaces'};
+    $tmp->{'tags'}          = $params->{'tags'};
+    $tmp->{'version'}       = "1.0";
+    $tmp->{'action'}        = "provision";
 
     my $circuit_layout = XMLout($tmp);
 
@@ -7617,7 +7622,7 @@ sub edit_circuit {
         return {'success' => 1, 'circuit_id' => $circuit_id};
     }
 
-    my $result = $self->_execute_query("update circuit set description = ?, restore_to_primary = ?, static_mac = ?, type = ? where circuit_id = ?", [$description,$restore_to_primary,$static_mac, $type, $circuit_id]);
+    my $result = $self->_execute_query("update circuit set description = ?, restore_to_primary = ?, static_mac = ?, circuit_state = ?, type = ? where circuit_id = ?", [$description, $restore_to_primary, $static_mac, $state, $type, $circuit_id]);
     if (! defined $result){
         $self->_set_error("Unable to update circuit description.");
         $self->_rollback() if($do_commit);


### PR DESCRIPTION
This should fix the remaining problems with scheduling related to static mac circuits.