### PR TITLE
Fixes, additions, tweaks for oess-frontend specfile

### DIFF
--- a/frontend/oess-frontend.spec
+++ b/frontend/oess-frontend.spec
@@ -23,6 +23,7 @@ BuildArch:	noarch
 
 
 %define destdir %{_datadir}/%{name}/
+%define subdirs www webservice conf docs
 
 %prep
 %setup -q
@@ -35,33 +36,23 @@ BuildArch:	noarch
 rm -rf $RPM_BUILD_ROOT
 
 %{__mkdir} -p -m 0755 %{buildroot}/%{_datadir}/%{name}/
-%{__mkdir} -p -m 0755 %{buildroot}/%{_datadir}/%{name}/www/
-%{__mkdir} -p -m 0755 %{buildroot}/%{_datadir}/%{name}/webservice/
-%{__mkdir} -p -m 0755 %{buildroot}/%{_datadir}/%{name}/conf/
-%{__mkdir} -p -m 0755 %{buildroot}/%{_datadir}/%{name}/docs/
 %{__mkdir} -p -m 0755 %{buildroot}/etc/httpd/conf.d/
 
-
-cp -ar www/* %{buildroot}%{destdir}/www/
-cp -ar webservice/* %{buildroot}%{destdir}/webservice/
-cp -ar conf/* %{buildroot}%{destdir}/conf/
-cp -ar docs/* %{buildroot}%{destdir}/docs/
+chmod 755 %{subdirs}
+cp -ar %{subdirs} %{buildroot}%{destdir}/
 
 %{__install} conf/oe-ss.conf.example %{buildroot}/etc/httpd/conf.d/oe-ss.conf
-
-find . -type f | sed 's:./:%{destdir}/:' |grep -v spec |grep -v Makefile> $RPM_BUILD_DIR/file.list.%{name}
 
 
 %clean
 rm -rf $RPM_BUILD_ROOT
 
 
-%files -f ../file.list.%{name}
+%files
 
+/%{destdir}
 %config(noreplace) /etc/httpd/conf.d/oe-ss.conf
-
-
-%doc
+%doc /%{destdir}/docs
 
 %post
 mkdir -p %{_sysconfdir}/oess/

--- a/frontend/oess-frontend.spec
+++ b/frontend/oess-frontend.spec
@@ -18,6 +18,9 @@ Requires:       nddi-tiles
 Requires:	perl-Crypt-SSLeay
 Requires:	xmlsec1
 Requires:	xmlsec1-openssl
+Requires:	python >= 2.6
+Requires:	python-libs >= 2.6
+Requires:	python-simplejson
 BuildArch:	noarch
 %description
 


### PR DESCRIPTION
As mentioned in ticket 2726:160, the frontend was unbuildable on the current (as of last week) 1.2.0-dev. This contains a potential fix, ready for review, as well as some additional dependencies and some tweaks in the build script.