### PR TITLE
Added forgotten definition of $node_id

### DIFF
--- a/perl-lib/OESS/lib/OESS/MPLS/FWDCTL.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/FWDCTL.pm
@@ -736,6 +736,8 @@ sub addVlan{
     foreach my $node (keys %nodes){
         $cv->begin();
 
+        my $node_id = $self->{'node_info'}->{$node}->{'id'};
+
         $self->{'fwdctl_events'}->{'topic'} = "MPLS.FWDCTL.Switch." . $self->{'node_by_id'}->{$node_id}->{'mgmt_addr'};
         $self->{'fwdctl_events'}->add_vlan(
             circuit_id => $circuit_id,


### PR DESCRIPTION
With this change, oess-mpls_fwdctl now starts up without bombing out with a Perl error.