### PR TITLE
Moved declaration of timeout value to proper place

### DIFF
--- a/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
@@ -106,6 +106,7 @@ sub new{
 							  port => $self->{'db'}->{'rabbitMQ'}->{'port'},
 							  user => $self->{'db'}->{'rabbitMQ'}->{'user'},
 							  pass => $self->{'db'}->{'rabbitMQ'}->{'pass'},
+							  timeout => 15,
 							  exchange => 'OESS',
 							  topic => 'MPLS.Discovery');
     
@@ -329,8 +330,7 @@ sub path_handler {
     
     foreach my $node (@{$nodes}){ 
         $self->{'rmq_client'}->{'topic'} = "MPLS.Discovery.Switch." . $node->{'mgmt_addr'};
-        $self->{'rmq_client'}->get_default_paths( timeout            => 15,
-                                                  loopback_addresses => \@loopback_addrs,
+        $self->{'rmq_client'}->get_default_paths( loopback_addresses => \@loopback_addrs,
                                                   async_callback     => sub {
                                                       my $res = shift;
                                                       warn "Processing results\n";

--- a/perl-lib/OESS/lib/OESS/MPLS/FWDCTL.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/FWDCTL.pm
@@ -80,6 +80,7 @@ sub new {
                                                              port => $self->{'db'}->{'rabbitMQ'}->{'port'},
                                                              user => $self->{'db'}->{'rabbitMQ'}->{'user'},
                                                              pass => $self->{'db'}->{'rabbitMQ'}->{'pass'},
+                                                             timeout => 15,
                                                              exchange => 'OESS',
                                                              topic => 'MPLS.FWDCTL.event');
 
@@ -912,8 +913,7 @@ sub diff {
 
                 warn "Diff topic! MPLS.FWDCTL.Switch." . $self->{'node_by_id'}->{$node_id}->{'mgmt_addr'} . "\n";
                 $self->{'fwdctl_events'}->{'topic'} = "MPLS.FWDCTL.Switch." . $self->{'node_by_id'}->{$node_id}->{'mgmt_addr'};
-                $self->{'fwdctl_events'}->diff( timeout        => 15,
-                                                installed_circuits => $payload,
+                $self->{'fwdctl_events'}->diff( installed_circuits => $payload,
                                                 force_diff     => $force_diff,
                                                 async_callback => sub {
                                                     my $res = shift;


### PR DESCRIPTION
In GRNOC::RabbitMQ::Client, 'timeout' is a per-client property, not a per-method-invocation property.