### PR TITLE
Setting the correct rabbitmq topic for scheduled events 

### DIFF
--- a/frontend/www/html_templates/scheduling.html
+++ b/frontend/www/html_templates/scheduling.html
@@ -22,7 +22,7 @@
 
 	<div style="padding: 10px 0px 20px 20px;">
 	  <input type="radio" name="provision_time" value="-1"> Now
-	  <input type="radio" name="provision_time" value=""> Later
+	  <input type="radio" name="provision_time" value="-1"> Later
 	  <div id="provision_time_display" class="provision_time_selection" style="display: none;"></div>
 	</div>
 

--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -7830,6 +7830,7 @@ sub edit_circuit {
 
     # do a quick check on arguments passed in
     if($do_sanity_check && !$self->circuit_sanity_check(%args)){
+	$self->_set_error("Could not perform circuit sanity check.");
         return;
     }
 
@@ -8446,6 +8447,8 @@ sub _validate_endpoint {
     my $vlan_tag_range;
     my $additional_vlan_range;
 
+    $self->{'logger'}->debug("Calling _validate_endpoint: " . Dumper(%args));
+
     my $query = "SELECT interface.role " .
       "FROM interface " .
       "WHERE interface.interface_id = ?";
@@ -8492,16 +8495,16 @@ sub _validate_endpoint {
         }
 
         if ($type eq 'openflow') {
-            $vlan_tag_range = @{$results}[0]->{'vlan_tag_range'};
+            $vlan_tag_range = $results->[0]->{'vlan_tag_range'};
         } else {
-            $vlan_tag_range = @{$results}[0]->{'mpls_vlan_tag_range'};
+            $vlan_tag_range = $results->[0]->{'mpls_vlan_tag_range'};
         }
     }
 
     if (!defined $vlan_tag_range) {
         $vlan_tag_range = '-1';
     }
-    $self->{'logger'}->debug("VLAN TAG RANGE $type -> $vlan_tag_range");
+    $self->{'logger'}->debug("VLAN TAG RANGE $type: $vlan_tag_range");
 
 
     $query  = "select * ";
@@ -8837,6 +8840,7 @@ sub validate_endpoints {
     my $mac_addresses  = $args{'mac_addresses'};
     my $static_mac     = $args{'static_mac'} || 0; 
     my $endpoint_mac_address_nums = $args{'endpoint_mac_address_nums'};
+    my $type                      = $args{'type'} || 'openflow';
 
     for (my $i = 0; $i < @$nodes; $i++){
         my $node      = @$nodes[$i];
@@ -8854,7 +8858,7 @@ sub validate_endpoints {
             return;
         }
 
-        if (! $self->_validate_endpoint(interface_id => $interface_id, workgroup_id => $workgroup_id, vlan => $vlan)){
+        if (! $self->_validate_endpoint(interface_id => $interface_id, workgroup_id => $workgroup_id, vlan => $vlan, type => $type)){
             $self->_set_error("Interface \"$interface\" on endpoint \"$node\" with VLAN tag \"$vlan\" is not allowed for this workgroup.");
             return;
         }
@@ -8924,6 +8928,13 @@ sub validate_paths {
             interface => @$interfaces[$i],
             vlan => @$tags[$i]
         });        
+    }
+
+    # MPLS circuits without links are auto-provisioned by the
+    # routers. We can skip validation here.
+    if ($args{'type'} eq 'mpls' && (!defined $args{'links'} || scalar @{$args{'links'}} == 0)) {
+        $self->{'logger'}->info("Skipping path validation for mpls circuit with no links.");
+        return 1;
     }
 
     # now check to verify that the topology makes sense

--- a/perl-lib/OESS/lib/OESS/MPLS/FWDCTL.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/FWDCTL.pm
@@ -122,6 +122,7 @@ sub new {
     #from TOPO startup
     my $nodes = $self->{'db'}->get_current_nodes( mpls => 1);
     foreach my $node (@$nodes) {
+	warn Dumper($node);
 	$self->make_baby($node->{'node_id'});
     }
 
@@ -488,6 +489,8 @@ sub make_baby {
     my $self = shift;
     my $id = shift;
     
+    return 1 if(defined($self->{'children'}->{$id}->{'rpc'}) && $self->{'children'}->{$id}->{'rpc'} == 1);
+
     $self->{'logger'}->debug("Before the fork");
     
     my $node = $self->{'node_by_id'}->{$id};

--- a/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
@@ -41,8 +41,6 @@ sub new{
     my $self = \%args;
     bless $self, $class;
 
-    $0 = "oess_mpls_switch(" . $self->{'node'}->{'mgmt_addr'} . ")";
-
     $self->{'logger'} = Log::Log4perl->get_logger('OESS.MPLS.Switch.' . $self->{'id'});
     $self->{'config'} = $args{'config'} || '/etc/oess/database.xml';
 
@@ -51,6 +49,8 @@ sub new{
     if($self->{'use_cache'}){
 	$self->_update_cache();
     }
+
+    $0 = "oess_mpls_switch(" . $self->{'node'}->{'mgmt_addr'} . ")";
 
     $self->create_device_object();
     if(!defined($self->{'device'})){


### PR DESCRIPTION
MPLS and OpenFlow have different forwarding engines. Previously
the scheduler sent all events to the OpenFlow engine which
caused MPLS events to fail.