### PR TITLE
Inform user about a node that is already in maintenance mode ISSUE=3299

### DIFF
--- a/frontend/webservice/admin/maintenance.cgi
+++ b/frontend/webservice/admin/maintenance.cgi
@@ -276,8 +276,14 @@ sub start_node_maintenance {
     $db->_start_transaction();
     my $data = $db->start_node_maintenance($node_id, $description);
     if (!defined $data) {
+        my $err_msg = $db->get_error();
         $db->_rollback();
-        $method->set_error("Failed to put node into maintenance mode; Database error occurred.");
+
+        if($err_msg eq OESS::Database::ERR_NODE_ALREADY_IN_MAINTENANCE) {
+            $method->set_error("The node is already in maintenance mode.");
+        } else {
+            $method->set_error("Failed to put node into maintenance mode; Database error occurred.");
+        }
 	return;
     }
     $db->_commit();

--- a/frontend/www/js_templates/admin.js
+++ b/frontend/www/js_templates/admin.js
@@ -3203,7 +3203,11 @@ function setup_network_tab(){
 
                     ds.responseSchema = {
                         resultsList: "results",
-                        fields: [{key: "maintenance_id"}]
+                        fields: [{key: "maintenance_id"}],
+                        metaFields: {
+                            error: "error",
+                            error_text: "error_text"
+                        }
                         }; 
 
                     ds.sendRequest("", 
@@ -3213,7 +3217,13 @@ function setup_network_tab(){
                                maint_button.set("label", "Put Device in Maintenance");
                                save_button.set("disabled", false);
 
-                               if (resp.results && resp.results[0].maintenance_id){
+                               if (resp.meta.error) {
+                                   var err_txt = resp.meta.error_text;
+                                   if (!YAHOO.lang.isString(err_txt)) err_txt = resp.meta.error;
+                                   if (!YAHOO.lang.isString(err_txt)) err_txt = "Error putting device into maintenance.";
+                                   alert(err_txt);
+                               }
+                               else if (resp.results && resp.results[0].maintenance_id){
                                    map.reinitialize();
                                    panel.destroy();
                                    panel = null;

--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -98,6 +98,8 @@ use constant FWDCTL_SUCCESS     => 1;
 use constant FWDCTL_FAILURE     => 0;
 use constant FWDCTL_UNKNOWN     => 3;
 
+use constant ERR_NODE_ALREADY_IN_MAINTENANCE => "Node is already in maintenance mode.";
+
 our $ENABLE_DEVEL=0;
 
 =head1 PUBLIC METHODS
@@ -2273,7 +2275,7 @@ sub start_node_maintenance {
     my $sql1 = "SELECT m.maintenance_id FROM maintenance as m, node_maintenance as n where m.maintenance_id = n.maintenance_id AND m.end_epoch = -1 AND n.node_id = ?";
     my $node_maintenance = $self->_execute_query($sql1, [$node_id]);
     if (defined @$node_maintenance[0]) {
-        $self->_set_error("Node is already in maintenance mode.");
+        $self->_set_error(ERR_NODE_ALREADY_IN_MAINTENANCE);
         return;
     }
 

--- a/perl-lib/OESS/t/database-46-start_node_maintenance-twice.t
+++ b/perl-lib/OESS/t/database-46-start_node_maintenance-twice.t
@@ -1,0 +1,39 @@
+#!/usr/bin/perl -T
+
+use strict;
+
+use FindBin;
+my $path;
+
+BEGIN {
+    if($FindBin::Bin =~ /(.*)/){
+            $path = $1;
+      }
+}
+
+use lib "$path";
+use OESS::Database;
+use OESSDatabaseTester;
+
+use Test::More tests => 6;
+use Data::Dumper;
+
+my $db = OESS::Database->new( config => OESSDatabaseTester::getConfigFilePath() );
+
+ok(defined(OESS::Database::ERR_NODE_ALREADY_IN_MAINTENANCE), 'ERR_NODE_ALREADY_IN_MAINTENANCE should be exported');
+
+# We put a random node into maintenance mode
+my $res = $db->start_node_maintenance(41, 'a random description');
+
+ok(defined($res), 'we can put a node into maintenance mode');
+ok(defined($res->{'node'}) && $res->{'node'}->{'name'} == 'Node 41', 'the right node was put into maintenance mode');
+
+# We try to put the node into maintenance mode while it's already in
+# maintenance mode; it should fail
+$res = $db->start_node_maintenance(41, 'another random description');
+
+ok(!defined($res), 'putting a node into maintenance mode should fail if it is already in maintenance mode');
+ok($db->get_error() eq OESS::Database::ERR_NODE_ALREADY_IN_MAINTENANCE, 'right error should be set for maintenance-in-maintenance attempt');
+
+
+ok(&OESSDatabaseTester::resetOESSDB(), "Resetting OESS Database");


### PR DESCRIPTION
This is intended to fix issue 3299, where we weren't adequately informing the user when they try to put into maintenance mode a node that is already in maintenance mode.

I'm confident the changes to OESS::Database and maintenance.cgi are good. I'm not so sure about the UI changes I made - in particular, they haven't been tested. I wouldn't mind some assistance with that.