### PR TITLE
Adding edit endpoint button back to options page

### DIFF
--- a/frontend/www/js_templates/options.js
+++ b/frontend/www/js_templates/options.js
@@ -40,11 +40,6 @@ function init(){
     var endpoint_table = summary_init();
     endpoint_table.hideColumn('mac_addrs');
 
-    // yui-dt-col7 is an alias for the column of the edit
-    // buttons. This is hidden for the options page due to issue
-    // 160:3834.
-    endpoint_table.hideColumn('yui-dt-col7');
-
     // OpenFlow Circuit Options
     const restore_to_primary = new YAHOO.widget.Button('restore_to_primary_button', {
         type:  'button',

--- a/frontend/www/js_templates/primary_path.js
+++ b/frontend/www/js_templates/primary_path.js
@@ -44,6 +44,12 @@ function init(){
 
   // defined in circuit_details_box.js
   var endpoint_table = summary_init();
+
+  // yui-dt-col7 is an alias for the column of the edit
+  // buttons. This was hidden on the options page due to issue
+  // 160:3834, but the options page needs this for static mac
+  // circuits.
+  endpoint_table.hideColumn('yui-dt-col7');
   
   var path_table = makePathTable();
   


### PR DESCRIPTION
The edit endpoint button is required for static mac circuits
on the options page. After the options page it is no longer
required and is hidden from the user.