### PR TITLE
removes queue name from exclusive queue

### DIFF
--- a/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
@@ -71,7 +71,6 @@ sub new{
                                                        user => $args{'rabbitMQ_user'},
                                                        pass => $args{'rabbitMQ_pass'},
                                                        topic => $topic,
-                                                       queue => $topic,
                                                        exchange => 'OESS',
                                                        exclusive => 1);
     $self->register_rpc_methods( $dispatcher );


### PR DESCRIPTION
Since we have two consumers on this topic, using the same named queue results in lost messages.