### PR TITLE
Schema fixes ISSUE=4154

### DIFF
--- a/perl-lib/OESS/share/nddi.sql
+++ b/perl-lib/OESS/share/nddi.sql
@@ -102,6 +102,45 @@ CREATE TABLE `circuit_instantiation` (
 /*!40101 SET character_set_client = utf8 */;
 
 --
+-- Table structure for table `edge_interface_move_maintenance`
+--
+
+DROP TABLE IF EXISTS `edge_interface_move_maintenance`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `edge_interface_move_maintenance` (
+  `maintenance_id` int(10) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `orig_interface_id` int(10) NOT NULL,
+  `temp_interface_id` int(10) NOT NULL,
+  `start_epoch` int(10) NOT NULL,
+  `end_epoch` int(10) DEFAULT '-1',
+  PRIMARY KEY (`maintenance_id`),
+  KEY `orig_interface_id` (`orig_interface_id`),
+  KEY `temp_interface_id` (`temp_interface_id`),
+  CONSTRAINT `edge_interface_move_maintenance_ibfk_1` FOREIGN KEY (`orig_interface_id`) REFERENCES `interface` (`interface_id`),
+  CONSTRAINT `edge_interface_move_maintenance_ibfk_2` FOREIGN KEY (`temp_interface_id`) REFERENCES `interface` (`interface_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `edge_interface_move_maintenance_circuit_membership`
+--
+
+DROP TABLE IF EXISTS `edge_interface_move_maintenance_circuit_membership`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `edge_interface_move_maintenance_circuit_membership` (
+  `maintenance_id` int(10) NOT NULL,
+  `circuit_id` int(10) NOT NULL,
+  KEY `maintenance_id` (`maintenance_id`),
+  KEY `circuit_id` (`circuit_id`),
+  CONSTRAINT `edge_interface_move_maintenance_circuit_membership_ibfk_1` FOREIGN KEY (`maintenance_id`) REFERENCES `edge_interface_move_maintenance` (`maintenance_id`) ON DELETE CASCADE,
+  CONSTRAINT `edge_interface_move_maintenance_circuit_membership_ibfk_2` FOREIGN KEY (`circuit_id`) REFERENCES `circuit` (`circuit_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `interface`
 --
 
@@ -221,6 +260,21 @@ CREATE TABLE `link_instantiation` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `link_maintenance`
+--
+
+DROP TABLE IF EXISTS `link_maintenance`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `link_maintenance` (
+  `link_maintenance_id` int(11) NOT NULL AUTO_INCREMENT,
+  `link_id` int(11) NOT NULL,
+  `maintenance_id` int(11) NOT NULL,
+  PRIMARY KEY (`link_maintenance_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `link_path_membership`
 --
 
@@ -240,6 +294,22 @@ CREATE TABLE `link_path_membership` (
   KEY `path_link_path_membership_fk` (`path_id`),
   CONSTRAINT `links_link_path_membership_fk` FOREIGN KEY (`link_id`) REFERENCES `link` (`link_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   CONSTRAINT `path_link_path_membership_fk` FOREIGN KEY (`path_id`) REFERENCES `path` (`path_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `maintenance`
+--
+
+DROP TABLE IF EXISTS `maintenance`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `maintenance` (
+  `maintenance_id` int(11) NOT NULL AUTO_INCREMENT,
+  `description` varchar(255),
+  `start_epoch` int(11),
+  `end_epoch` int(11) DEFAULT -1,
+  PRIMARY KEY (`maintenance_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -317,6 +387,21 @@ CREATE TABLE `node_instantiation` (
   PRIMARY KEY (`node_id`,`end_epoch`),
   UNIQUE KEY `node_instantiation_idx` (`end_epoch`,`dpid`),
   CONSTRAINT `node_node_instantiation_fk` FOREIGN KEY (`node_id`) REFERENCES `node` (`node_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `node_maintenance`
+--
+
+DROP TABLE IF EXISTS `node_maintenance`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `node_maintenance` (
+  `node_maintenance_id` int(11) NOT NULL AUTO_INCREMENT,
+  `node_id` int(11) NOT NULL,
+  `maintenance_id` int(11) NOT NULL,
+  PRIMARY KEY (`node_maintenance_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -474,16 +559,6 @@ CREATE TABLE `user` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Dumping data for table `user`
---
-
-LOCK TABLES `user` WRITE;
-/*!40000 ALTER TABLE `user` DISABLE KEYS */;
-INSERT INTO `user` VALUES (1,'system@localhost','system','system',0,'normal','active');
-/*!40000 ALTER TABLE `user` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
 -- Table structure for table `user_workgroup_membership`
 --
 
@@ -540,91 +615,6 @@ CREATE TABLE `workgroup_node_membership` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Table structure for table `edge_interface_move_maintenance`
---
-
-DROP TABLE IF EXISTS `edge_interface_move_maintenance`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `edge_interface_move_maintenance` (
-  `maintenance_id` int(10) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL,
-  `orig_interface_id` int(10) NOT NULL,
-  `temp_interface_id` int(10) NOT NULL,
-  `start_epoch` int(10) NOT NULL,
-  `end_epoch` int(10) DEFAULT '-1',
-  PRIMARY KEY (`maintenance_id`),
-  KEY `orig_interface_id` (`orig_interface_id`),
-  KEY `temp_interface_id` (`temp_interface_id`),
-  CONSTRAINT `edge_interface_move_maintenance_ibfk_1` FOREIGN KEY (`orig_interface_id`) REFERENCES `interface` (`interface_id`),
-  CONSTRAINT `edge_interface_move_maintenance_ibfk_2` FOREIGN KEY (`temp_interface_id`) REFERENCES `interface` (`interface_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Table structure for table `edge_interface_move_maintenance_circuit_membership`
---
-
-DROP TABLE IF EXISTS `edge_interface_move_maintenance_circuit_membership`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `edge_interface_move_maintenance_circuit_membership` (
-  `maintenance_id` int(10) NOT NULL,
-  `circuit_id` int(10) NOT NULL,
-  KEY `maintenance_id` (`maintenance_id`),
-  KEY `circuit_id` (`circuit_id`),
-  CONSTRAINT `edge_interface_move_maintenance_circuit_membership_ibfk_1` FOREIGN KEY (`maintenance_id`) REFERENCES `edge_interface_move_maintenance` (`maintenance_id`) ON DELETE CASCADE,
-  CONSTRAINT `edge_interface_move_maintenance_circuit_membership_ibfk_2` FOREIGN KEY (`circuit_id`) REFERENCES `circuit` (`circuit_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Table structure for table `maintenance`
---
-
-DROP TABLE IF EXISTS `maintenance`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `maintenance` (
-  `maintenance_id` int(11) NOT NULL AUTO_INCREMENT,
-  `description` varchar(255),
-  `start_epoch` int(11),
-  `end_epoch` int(11) DEFAULT -1,
-  PRIMARY KEY (`maintenance_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Table structure for table `node_maintenance`
---
-
-DROP TABLE IF EXISTS `node_maintenance`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `node_maintenance` (
-  `node_maintenance_id` int(11) NOT NULL AUTO_INCREMENT,
-  `node_id` int(11) NOT NULL,
-  `maintenance_id` int(11) NOT NULL,
-  PRIMARY KEY (`node_maintenance_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Table structure for table `link_maintenance`
---
-
-DROP TABLE IF EXISTS `link_maintenance`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `link_maintenance` (
-  `link_maintenance_id` int(11) NOT NULL AUTO_INCREMENT,
-  `link_id` int(11) NOT NULL,
-  `maintenance_id` int(11) NOT NULL,
-  PRIMARY KEY (`link_maintenance_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
 -- Table structure for table `oess_version`
 --
 
@@ -644,6 +634,16 @@ LOCK TABLES `oess_version` WRITE;
 /*!40000 ALTER TABLE `oess_version` DISABLE KEYS */;
 INSERT INTO `oess_version` VALUES ('1.2.0');
 /*!40000 ALTER TABLE `oess_version` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Dumping data for table `user`
+--
+
+LOCK TABLES `user` WRITE;
+/*!40000 ALTER TABLE `user` DISABLE KEYS */;
+INSERT INTO `user` VALUES (1,'system@localhost','system','system',0,'normal','active');
+/*!40000 ALTER TABLE `user` ENABLE KEYS */;
 UNLOCK TABLES;
 
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;

--- a/perl-lib/OESS/share/nddi.sql
+++ b/perl-lib/OESS/share/nddi.sql
@@ -38,9 +38,8 @@ CREATE TABLE `circuit` (
   UNIQUE KEY `circuit_idx` (`name`),
   KEY `workgroup_id` (`workgroup_id`),
   CONSTRAINT `circuit_ibfk_1` FOREIGN KEY (`workgroup_id`) REFERENCES `workgroup` (`workgroup_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=3000 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = utf8 */;
-ALTER TABLE circuit AUTO_INCREMENT=3000;
 --
 -- Table structure for table `circuit_edge_interface_membership`
 --
@@ -118,12 +117,13 @@ CREATE TABLE `interface` (
   `role` enum('unknown','trunk','customer') NOT NULL DEFAULT 'unknown',
   `node_id` int(10) NOT NULL,
   `vlan_tag_range` varchar(255) DEFAULT '-1,1-4095',
-  `mpls_vlan_tag_range` varchar(255) DEFAULT '0',
+  `mpls_vlan_tag_range` varchar(255) DEFAULT NULL,
   `workgroup_id` int(10) DEFAULT NULL,
   PRIMARY KEY (`interface_id`),
   UNIQUE KEY `node_id_name_idx` (`node_id`,`name`),
   UNIQUE KEY `node_port_idx` (`node_id`,`port_number`),
   KEY `node_interface_fk` (`node_id`),
+  KEY `interface_ibfk_1` (`workgroup_id`),
   CONSTRAINT `interface_ibfk_1` FOREIGN KEY (`workgroup_id`) REFERENCES `workgroup` (`workgroup_id`),
   CONSTRAINT `node_interface_fk` FOREIGN KEY (`node_id`) REFERENCES `node` (`node_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
@@ -183,7 +183,7 @@ CREATE TABLE `link` (
   `link_id` int(10) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   `remote_urn` varchar(256) DEFAULT NULL,
-  `status` enum('up','down','unknown') DEFAULT 'up',
+  `status` enum('up','down','unknown') NOT NULL DEFAULT 'unknown',
   `metric` int(11) DEFAULT '1',
   `fv_status` enum('up','down','unknown') NOT NULL DEFAULT 'unknown',
   `vlan_tag_range` varchar(255) DEFAULT NULL,
@@ -233,7 +233,7 @@ CREATE TABLE `link_path_membership` (
   `path_id` int(10) NOT NULL,
   `start_epoch` int(10) NOT NULL,
   `interface_a_vlan_id` int(11) NOT NULL,
-  `interface_z_vlan_id` int(11) NOT NULL,        
+  `interface_z_vlan_id` int(11) NOT NULL,
   PRIMARY KEY (`link_id`,`end_epoch`,`path_id`,`interface_a_vlan_id`,`interface_z_vlan_id`),
   UNIQUE KEY `unique_vlan_a` (`link_id`,`end_epoch`,`interface_a_vlan_id`),
   UNIQUE KEY `unique_vlan_z` (`link_id`,`end_epoch`,`interface_z_vlan_id`),
@@ -313,7 +313,7 @@ CREATE TABLE `node_instantiation` (
   `sw_version` varchar(255),
   `mgmt_addr` varchar(255),
   `loopback_address` varchar(255),
-  `tcp_port` int DEFAULT 830,
+  `tcp_port` int(6) DEFAULT 830,
   PRIMARY KEY (`node_id`,`end_epoch`),
   UNIQUE KEY `node_instantiation_idx` (`end_epoch`,`dpid`),
   CONSTRAINT `node_node_instantiation_fk` FOREIGN KEY (`node_id`) REFERENCES `node` (`node_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
@@ -572,7 +572,9 @@ CREATE TABLE `edge_interface_move_maintenance_circuit_membership` (
   `maintenance_id` int(10) NOT NULL,
   `circuit_id` int(10) NOT NULL,
   KEY `maintenance_id` (`maintenance_id`),
-  KEY `circuit_id` (`circuit_id`)
+  KEY `circuit_id` (`circuit_id`),
+  CONSTRAINT `edge_interface_move_maintenance_circuit_membership_ibfk_1` FOREIGN KEY (`maintenance_id`) REFERENCES `edge_interface_move_maintenance` (`maintenance_id`) ON DELETE CASCADE,
+  CONSTRAINT `edge_interface_move_maintenance_circuit_membership_ibfk_2` FOREIGN KEY (`circuit_id`) REFERENCES `circuit` (`circuit_id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -584,10 +586,10 @@ DROP TABLE IF EXISTS `maintenance`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `maintenance` (
-  `maintenance_id` int(10) NOT NULL AUTO_INCREMENT,
+  `maintenance_id` int(11) NOT NULL AUTO_INCREMENT,
   `description` varchar(255),
-  `start_epoch` int(10),
-  `end_epoch` int(10) DEFAULT -1,
+  `start_epoch` int(11),
+  `end_epoch` int(11) DEFAULT -1,
   PRIMARY KEY (`maintenance_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -600,24 +602,24 @@ DROP TABLE IF EXISTS `node_maintenance`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `node_maintenance` (
-  `node_maintenance_id` int(10) NOT NULL AUTO_INCREMENT,
-  `node_id` int(10) NOT NULL,
-  `maintenance_id` int(10) NOT NULL,
+  `node_maintenance_id` int(11) NOT NULL AUTO_INCREMENT,
+  `node_id` int(11) NOT NULL,
+  `maintenance_id` int(11) NOT NULL,
   PRIMARY KEY (`node_maintenance_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Table structure for table `node_maintenance`
+-- Table structure for table `link_maintenance`
 --
 
 DROP TABLE IF EXISTS `link_maintenance`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `link_maintenance` (
-  `link_maintenance_id` int(10) NOT NULL AUTO_INCREMENT,
-  `link_id` int(10) NOT NULL,
-  `maintenance_id` int(10) NOT NULL,
+  `link_maintenance_id` int(11) NOT NULL AUTO_INCREMENT,
+  `link_id` int(11) NOT NULL,
+  `maintenance_id` int(11) NOT NULL,
   PRIMARY KEY (`link_maintenance_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/perl-lib/OESS/share/upgrade/oess-1.1.9-1.2.0
+++ b/perl-lib/OESS/share/upgrade/oess-1.1.9-1.2.0
@@ -60,16 +60,33 @@ sub upgrade{
     $dbh->do("alter table circuit add column type enum('openflow', 'mpls') default 'openflow'");
     $dbh->do("alter table link_instantiation add column openflow int(1) not null default 0");
     $dbh->do("alter table link_instantiation add column mpls int(1) not null default 0");
-    $dbh->do("alter table interface add column mpls_vlan_tag_range varchar(255)");
+    $dbh->do("alter table interface add column mpls_vlan_tag_range varchar(255) default null");
     $dbh->do("alter table link_instantiation add column ip_a varchar(255)");
     $dbh->do("alter table link_instantiation add column ip_z varchar(255)");
     $dbh->do("alter table node_instantiation add column loopback_address varchar(255)");
-    $dbh->do("alter table node_instantiation add column netconf_port int default 830");
+    $dbh->do("alter table node_instantiation add column tcp_port int(6) default 830");
     $dbh->do("alter table path add column mpls_path_type enum('strict','loose','none') NOT NULL default 'none'");
     $dbh->do("alter table path modify path_type enum('primary','backup','tertiary') NOT NULL DEFAULT 'primary'");
     $dbh->do("alter table node add column pending_diff int(1) default 0");
     $dbh->do("alter table node add column operational_state_mpls enum('unknown','up','down') NOT NULL DEFAULT 'unknown'");
     $dbh->do("alter table node add column short_name varchar(255)");
+
+    $dbh->do("alter table interface add key interface_ibfk_1 (workgroup_id)");
+    $dbh->do("alter table link modify column status enum('up','down','unknown') NOT NULL DEFAULT 'unknown'");
+    $dbh->do("alter table link_maintenance modify column link_maintenance_id int(11) NOT NULL AUTO_INCREMENT");
+    $dbh->do("alter table link_maintenance modify column link_id int(11) NOT NULL");
+    $dbh->do("alter table link_maintenance modify column maintenance_id int(11) NOT NULL");
+    $dbh->do("alter table link_path_membership drop primary key");
+    $dbh->do("alter table link_path_membership add primary key (link_id,end_epoch,path_id,interface_a_vlan_id,interface_z_vlan_id)");
+    $dbh->do("alter table maintenance modify column maintenance_id int(11) NOT NULL AUTO_INCREMENT");
+    $dbh->do("alter table maintenance modify column start_epoch int(11)");
+    $dbh->do("alter table maintenance modify column end_epoch int(11) default -1");
+    $dbh->do("alter table node_maintenance modify column node_maintenance_id int(11) NOT NULL AUTO_INCREMENT");
+    $dbh->do("alter table node_maintenance modify column node_id int(11) NOT NULL");
+    $dbh->do("alter table node_maintenance modify column maintenance_id int(11) NOT NULL");
+    $dbh->do("alter table remote_auth modify column auth_name varchar(255) NOT NULL");
+    $dbh->do("alter table user modify column status enum('active','decom') NOT NULL DEFAULT 'active'");
+    $dbh->do("drop table if exists workgroup_interface_membership");
 
     # Done with the rest of the upgrade update our version
     $str = "update oess_version set version = '$version'";


### PR DESCRIPTION
Some fixes to the schema and the 1.2.0 schema upgrade script.

In testing, the upgrade script now appears to take an AL2S database dump and get it in line with nddi.sql (as these commits change it), and I'm not seeing schema-related error messages in the logs anymore.