### PR TITLE
Make sure that Log4perl's initialized before it's used ISSUE=4190

### DIFF
--- a/app/etc/fvd-init-rh
+++ b/app/etc/fvd-init-rh
@@ -141,7 +141,7 @@ case "$1" in
 
   restart)
         $0 stop
-        #wee need to sleep to make sure the deamon has enoth time to shutdown
+        # we need to sleep to make sure the daemon has enough time to shutdown
         sleep 3
         $0 start
         exit $?

--- a/app/etc/fwdctl-init-rh
+++ b/app/etc/fwdctl-init-rh
@@ -140,7 +140,7 @@ case "$1" in
 
   restart)
         $0 stop
-        #wee need to sleep to make sure the deamon has enoth time to shutdown
+        # we need to sleep to make sure the daemon has enough time to shutdown
         sleep 3
         $0 start
         exit $?

--- a/app/etc/mpls-discovery-init-rh
+++ b/app/etc/mpls-discovery-init-rh
@@ -140,7 +140,7 @@ case "$1" in
 
   restart)
         $0 stop
-        #wee need to sleep to make sure the deamon has enoth time to shutdown
+        # we need to sleep to make sure the daemon has enough time to shutdown
         sleep 3
         $0 start
         exit $?

--- a/app/etc/mpls-fwdctl-init-rh
+++ b/app/etc/mpls-fwdctl-init-rh
@@ -140,7 +140,7 @@ case "$1" in
 
   restart)
         $0 stop
-        #wee need to sleep to make sure the deamon has enoth time to shutdown
+        # we need to sleep to make sure the daemon has enough time to shutdown
         sleep 3
         $0 start
         exit $?

--- a/app/etc/notification-init-rh
+++ b/app/etc/notification-init-rh
@@ -140,7 +140,7 @@ case "$1" in
 
   restart)
         $0 stop
-        #wee need to sleep to make sure the deamon has enoth time to shutdown
+        # we need to sleep to make sure the daemon has enough time to shutdown
         sleep 3
         $0 start
         exit $?

--- a/app/etc/nsi-init-rh
+++ b/app/etc/nsi-init-rh
@@ -137,7 +137,7 @@ case "$1" in
 
   restart)
         $0 stop
-        #wee need to sleep to make sure the deamon has enoth time to shutdown
+        # we need to sleep to make sure the daemon has enough time to shutdown
         sleep 3
         $0 start
         exit $?

--- a/app/etc/oess-init-rh
+++ b/app/etc/oess-init-rh
@@ -7,6 +7,7 @@ use OESS::Database;
 use AnyEvent;
 use AnyEvent::DBus;
 use Net::DBus::Annotation qw(:call);
+use Log::Log4perl;
 use constant FWDCTL_WAITING     => 2;
 use constant FWDCTL_SUCCESS     => 1;
 use constant FWDCTL_FAILURE     => 0;
@@ -14,6 +15,8 @@ use constant FWDCTL_UNKNOWN     => 3;
 
 sub main{
     my $option = shift;
+
+    Log::Log4perl::init('/etc/oess/logging.conf');
 
     if($option eq 'stop'){
         exit(stop());

--- a/app/etc/oess-init-rh
+++ b/app/etc/oess-init-rh
@@ -24,7 +24,7 @@ sub main{
         exit($status);
     }elsif($option eq 'validate-all'){
         my $status = status();
-        #short circuit if status saysit isn't running no reason to go any further
+        # short circuit - if status says it isn't running, there's no reason to go any further
         if($status != 0){
             exit($status);
         }

--- a/app/etc/traceroute-init-rh
+++ b/app/etc/traceroute-init-rh
@@ -141,7 +141,7 @@ case "$1" in
 
   restart)
         $0 stop
-        #wee need to sleep to make sure the deamon has enoth time to shutdown
+        # we need to sleep to make sure the daemon has enough time to shutdown
         sleep 3
         $0 start
         exit $?

--- a/app/etc/vlan_stats-init
+++ b/app/etc/vlan_stats-init
@@ -137,7 +137,7 @@ case "$1" in
 
   restart)
         $0 stop
-        #wee need to sleep to make sure the deamon has enoth time to shutdown
+        # we need to sleep to make sure the daemon has enough time to shutdown
         sleep 3
         $0 start
         exit $?

--- a/app/etc/watchdog-init-rh
+++ b/app/etc/watchdog-init-rh
@@ -139,7 +139,7 @@ case "$1" in
 
   restart)
         $0 stop
-        #wee need to sleep to make sure the deamon has enoth time to shutdown
+        # we need to sleep to make sure the daemon has enough time to shutdown
         sleep 3
         $0 start
         exit $?

--- a/app/fwdctl.pl
+++ b/app/fwdctl.pl
@@ -119,7 +119,7 @@ sub main{
             core();
         }
     }
-    #not a deamon, just run the core;
+    #not a daemon, just run the core;
     else {
         $SIG{HUP} = sub{ exit(0); };
 	core();

--- a/app/mpls/mpls_discovery.pl
+++ b/app/mpls/mpls_discovery.pl
@@ -87,7 +87,7 @@ sub main{
             core();
         }
     }
-    #not a deamon, just run the core;
+    #not a daemon, just run the core;
     else {
         $SIG{HUP} = sub{ exit(0); };
         core();

--- a/app/mpls/mpls_fwdctl.pl
+++ b/app/mpls/mpls_fwdctl.pl
@@ -89,7 +89,7 @@ sub main{
             core();
         }
     }
-    #not a deamon, just run the core;
+    #not a daemon, just run the core;
     else {
         $SIG{HUP} = sub{ exit(0); };
         core();

--- a/app/oess-fvd.pl
+++ b/app/oess-fvd.pl
@@ -51,7 +51,7 @@ sub main{
         my $logger = Log::Log4perl->init_and_watch('/etc/oess/logging.conf');
         my $bfd = OESS::FV->new();
     }
-    #not a deamon, just run the core;
+    #not a daemon, just run the core;
     else {
         $SIG{HUP} = sub{ exit(0); };
         my $logger = Log::Log4perl->init_and_watch('/etc/oess/logging.conf');

--- a/app/oess-traceroute.pl
+++ b/app/oess-traceroute.pl
@@ -43,7 +43,7 @@ sub main{
             `chmod 0644 /var/run/oess/oess-traceroute.pid`;
             return;
         }
-    } else { # Not a deamon, just run the core;
+    } else { # Not a daemon, just run the core;
         $SIG{HUP} = sub{ exit(0); };
     }
 

--- a/app/oess-watchdog.pl
+++ b/app/oess-watchdog.pl
@@ -59,7 +59,7 @@ sub main{
         }
     }
 
-    #not a deamon, just run the core;
+    #not a daemon, just run the core;
     else {
         $SIG{HUP} = sub{ exit(0); };
         my $watchdog = OESS::Watchdog->new();

--- a/frontend/webservice/admin/admin.cgi
+++ b/frontend/webservice/admin/admin.cgi
@@ -33,6 +33,7 @@ use Data::Dumper;
 use JSON;
 use LWP::UserAgent;
 use Switch;
+use Log::Log4perl;
 
 use OESS::RabbitMQ::Client;
 use GRNOC::WebService;
@@ -45,6 +46,8 @@ use constant FWDCTL_WAITING     => 2;
 use constant FWDCTL_SUCCESS     => 1;
 use constant FWDCTL_FAILURE     => 0;
 use constant FWDCTL_UNKNOWN     => 3;
+
+Log::Log4perl::init('/etc/oess/logging.conf');
 
 my $conf = GRNOC::Config->new(config_file => '/etc/oess/database.xml');
 

--- a/frontend/webservice/admin/maintenance.cgi
+++ b/frontend/webservice/admin/maintenance.cgi
@@ -35,7 +35,10 @@ use JSON;
 use OESS::Database;
 use OESS::RabbitMQ::Client;
 use Switch;
+use Log::Log4perl;
 use GRNOC::WebService;
+
+Log::Log4perl::init('/etc/oess/logging.conf');
 
 my $db = new OESS::Database();
 my $mq = OESS::RabbitMQ::Client->new( topic    => 'OF.FWDCTL.RPC',

--- a/frontend/webservice/data.cgi
+++ b/frontend/webservice/data.cgi
@@ -57,6 +57,8 @@ use constant FWDCTL_FAILURE     => 0;
 use constant FWDCTL_UNKNOWN     => 3;
 use constant FWDCTL_BLOCKED     => 4;
 
+Log::Log4perl::init_and_watch('/etc/oess/logging.conf',10);
+
 my $db   = new OESS::Database();
 my $topo = new OESS::Topology();
 
@@ -65,8 +67,6 @@ my $svc    = GRNOC::WebService::Dispatcher->new(method_selector => ['method', 'a
 
 my $mq = OESS::RabbitMQ::Client->new( topic    => 'MPLS.FWDCTL.RPC',
                                       timeout  => 60 );
-
-Log::Log4perl::init_and_watch('/etc/oess/logging.conf',10);
 
 my $username = $ENV{'REMOTE_USER'};
 my $is_admin = $db->get_user_admin_status( 'username' => $username );

--- a/frontend/webservice/idc/idc.cgi
+++ b/frontend/webservice/idc/idc.cgi
@@ -7,7 +7,10 @@ use Data::Dumper;
 use OSCARS::pss;
 use XML::Simple;
 use Switch;
+use Log::Log4perl;
 
+
+Log::Log4perl::init('/etc/oess/logging.conf');
 
 my $cgi = new CGI;
 

--- a/frontend/webservice/idc/nsi.cgi
+++ b/frontend/webservice/idc/nsi.cgi
@@ -8,6 +8,9 @@ use OESS::NSI::Server;
 use Data::Dumper;
 use SOAP::Lite;
 use SOAP::Transport::HTTP;
+use Log::Log4perl;
+
+Log::Log4perl::init('/etc/oess/logging.conf');
 
 sub new_handler{
 

--- a/frontend/webservice/measurement.cgi
+++ b/frontend/webservice/measurement.cgi
@@ -34,11 +34,14 @@ use GRNOC::WebService;
 use JSON;
 use Switch;
 use Data::Dumper;
+use Log::Log4perl;
 
 use OESS::Database;
 use OESS::Topology;
 use OESS::Measurement qw(BUILDING_FILE);
 
+
+Log::Log4perl::init('/etc/oess/logging.conf');
 
 my $db          = new OESS::Database();
 my $topo        = new OESS::Topology();

--- a/frontend/webservice/monitoring.cgi
+++ b/frontend/webservice/monitoring.cgi
@@ -32,11 +32,14 @@ use warnings;
 use JSON;
 use Switch;
 use Data::Dumper;
+use Log::Log4perl;
 
 use OESS::Database;
 use OESS::RabbitMQ::Client;
 use OESS::Topology;
 use GRNOC::WebService;
+
+Log::Log4perl::init('/etc/oess/logging.conf');
 
 my $db   = new OESS::Database();
 my $topo = new OESS::Topology();

--- a/frontend/webservice/provisioning.cgi
+++ b/frontend/webservice/provisioning.cgi
@@ -29,6 +29,7 @@ use warnings;
 use JSON;
 use Switch;
 use Data::Dumper;
+use Log::Log4perl;
 
 use GRNOC::Config;
 use OESS::RabbitMQ::Client;
@@ -43,6 +44,8 @@ use constant FWDCTL_WAITING     => 2;
 use constant FWDCTL_SUCCESS     => 1;
 use constant FWDCTL_FAILURE     => 0;
 use constant FWDCTL_UNKNOWN     => 3;
+
+Log::Log4perl::init('/etc/oess/logging.conf');
 
 my $conf = GRNOC::Config->new(config_file => '/etc/oess/database.xml');
 

--- a/frontend/webservice/remote.cgi
+++ b/frontend/webservice/remote.cgi
@@ -40,12 +40,15 @@ use LWP::UserAgent;
 use Switch;
 use URI::Escape;
 use XML::XPath;
+use Log::Log4perl;
 
 use OESS::Database;
 use OESS::Topology;
 
 use OSCARS::Client;
 
+
+Log::Log4perl::init('/etc/oess/logging.conf');
 
 my $db   = new OESS::Database();
 my $topo = new OESS::Topology();

--- a/frontend/webservice/traceroute.cgi
+++ b/frontend/webservice/traceroute.cgi
@@ -30,6 +30,7 @@ use Switch;
 use OESS::RabbitMQ::Client;
 
 use Data::Dumper;
+use Log::Log4perl;
 
 use OESS::Database;
 use OESS::Topology;
@@ -39,6 +40,8 @@ use constant FWDCTL_WAITING     => 2;
 use constant FWDCTL_SUCCESS     => 1;
 use constant FWDCTL_FAILURE     => 0;
 use constant FWDCTL_UNKNOWN     => 3;
+
+Log::Log4perl::init('/etc/oess/logging.conf');
 
 my $db = new OESS::Database();
 my $mq = OESS::RabbitMQ::Client->new( topic    => 'OF.NDDI.RPC',

--- a/frontend/webservice/workgroup_manage.cgi
+++ b/frontend/webservice/workgroup_manage.cgi
@@ -30,6 +30,8 @@ use MIME::Lite;
 use OESS::Database;
 use GRNOC::WebService;
 
+Log::Log4perl::init_and_watch('/etc/oess/logging.conf');
+
 my $db   = new OESS::Database();
 
 #register web service dispatcher
@@ -52,7 +54,6 @@ sub main {
 	exit(1);
     }
 
-    my $init_logger = Log::Log4perl->init_and_watch('/etc/oess/logging.conf'); 
     $user_id = $db->get_user_id_by_auth_name( 'auth_name' => $username );
 
     my $user = $db->get_user_by_id( user_id => $user_id)->[0];

--- a/frontend/www/admin/index.cgi
+++ b/frontend/www/admin/index.cgi
@@ -14,6 +14,9 @@ use Template;
 use Switch;
 use FindBin;
 use OESS::Database();
+use Log::Log4perl;
+
+Log::Log4perl::init('/etc/oess/logging.conf');
 
 my $ADMIN_BREADCRUMBS = [
     { title => "Workgroups", url => "../index.cgi?action=workgroups" },

--- a/frontend/www/index.cgi
+++ b/frontend/www/index.cgi
@@ -38,6 +38,9 @@ use CGI;
 use Template;
 use Switch;
 use FindBin;
+use Log::Log4perl;
+
+Log::Log4perl::init('/etc/oess/logging.conf');
 
 my $db= OESS::Database->new();
 

--- a/nox/init/nox_cored
+++ b/nox/init/nox_cored
@@ -122,7 +122,7 @@ case "$1" in
 
   restart)
         $0 stop
-        #wee need to sleep to make sure the deamon has enoth time to shutdown
+        # we need to sleep to make sure the daemon has enough time to shutdown
         sleep 3
         $0 start
         exit $?

--- a/perl-lib/OESS/lib/OESS/FV.pm
+++ b/perl-lib/OESS/lib/OESS/FV.pm
@@ -382,7 +382,7 @@ sub _load_state {
 
 =head2 datapath_leave_callback
 
-event that firest for when a node leaves
+event that fires when a node leaves
 
 =cut
 
@@ -654,7 +654,7 @@ sub do_work {
 =head2 fv_packet_in_callback
 
 event that fires when a packet in event occurs and matches the
-forwarding verification deamon process
+forwarding verification daemon process
 
 =cut
 


### PR DESCRIPTION
This was causing a lot of extraneous log messages in the Apache logs, as well as some unattractive lines in the initscript.

I also included fixes for some typos in comments.