### PR TITLE
Adding missing call to AnyEvent->condvar->end

### DIFF
--- a/frontend/webservice/admin/admin.cgi
+++ b/frontend/webservice/admin/admin.cgi
@@ -1755,6 +1755,7 @@ sub update_node {
 			});
     }
 
+    $cv->end;
     $cv->recv();
 
     return {results => [{success => 1}]};


### PR DESCRIPTION
When using begin and end, both must be called in pairs. If
not subsequent calls to recv will block forever.