### PR TITLE
Removing debug print statements ISSUE=4192

### DIFF
--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -8724,7 +8724,6 @@ sub _validate_endpoint {
                     $vlan_range_hash->{$tag} = 0;
                 }
             }
-            warn Dumper($self->_vlan_range_hash2str( vlan_range_hash => $vlan_range_hash ));
         }
         # otherwise if our vlan falls within this rules range determine if it is allow
         # or deny

--- a/perl-lib/OESS/lib/OESS/Measurement.pm
+++ b/perl-lib/OESS/lib/OESS/Measurement.pm
@@ -70,7 +70,6 @@ sub new {
     $self->{'logger'} = Log::Log4perl->get_logger("OESS.Measurement");
     $self->{'db'} = $db;
     $self->{'config'} = $db->{'configuration'};
-    warn Dumper($self);
     return $self;
 
 }


### PR DESCRIPTION
These changes should make the Apache logs easier to scan in case of a problem. A little less likely to fill up the disk, too.