### PR TITLE
Style improvements for breadcrumbs, workgroup indicator ISSUE=4240

### DIFF
--- a/frontend/www/css/style.css
+++ b/frontend/www/css/style.css
@@ -96,6 +96,7 @@ div.breadcrumbs {
     float: left;
     font-size: 88%;
     margin-left: 35px;
+    margin-right: 2em;
 }
 
 div.breadcrumbs a {
@@ -206,10 +207,12 @@ div#workgroup_tabs .yui-content {
 
 
 div.active_workgroup_container {
-    float: right; 
-    font-size: 90%; 
-    margin-top: 90px;
-    margin-right: -70px;
+    font-size: 90%;
+    margin-right: 35px;
+    text-align: right;
+}
+
+div.active_workgroup_container::first-line {
     color: white;
 }
 

--- a/frontend/www/html_templates/page_base.html
+++ b/frontend/www/html_templates/page_base.html
@@ -59,18 +59,6 @@
 		   </div>
 	  </div>
 
-     <div id="active_workgroup_container" class="active_workgroup_container">
-       Workgroup: <span id="active_workgroup_name"></span>
-     </div>
-
-     <script>
-	   var oLinkButton1 = new YAHOO.widget.Button("docLink");
-	   var oLinkButton2 = new YAHOO.widget.Button("feedbackLink");
-	   [% IF is_admin == 1 %]
-	   var oLinkButton3 = new YAHOO.widget.Button("adminLink");
-       [% END %]
-	   makeHelpPanel("active_workgroup_container", "This is the current workgroup you are using.");
-     </script>
 
       <div class="top_nav">
 
@@ -109,6 +97,19 @@
 		
 	  [% END %]
 	</div>      
+
+        <div id="active_workgroup_container" class="active_workgroup_container">
+          Workgroup: <span id="active_workgroup_name"></span>
+        </div>
+
+        <script>
+          var oLinkButton1 = new YAHOO.widget.Button("docLink");
+          var oLinkButton2 = new YAHOO.widget.Button("feedbackLink");
+          [% IF is_admin == 1 %]
+          var oLinkButton3 = new YAHOO.widget.Button("adminLink");
+          [% END %]
+          makeHelpPanel("active_workgroup_container", "This is the current workgroup you are using.");
+        </script>
 
       </div>
 


### PR DESCRIPTION
This commit changes up the styling so that the breadcrumbs and active workgroup indicator will stay at the same vertical place in more cases, with the workgroup indicator ceding horizontal space in preference to the breadcrumbs.

It's not perfect, but it is an improvement.