### PR TITLE
Data table CSS fixes ISSUE=4239

### DIFF
--- a/frontend/www/css/style.css
+++ b/frontend/www/css/style.css
@@ -162,6 +162,11 @@ div#details_tabs .yui-content {
 div#workgroup_tabs .yui-content {
     background: white;
 }
+
+.yui-skin-sam .yui-dt-scrollable .yui-dt-hd {
+    text-align: left;
+}
+
 .yui-skin-sam .yui-navset-left .yui-nav .selected a {
     background: #2647A0 url(../yui/build/assets/skins/sam/sprite.png) repeat-x left -1400px !important;    
 }

--- a/frontend/www/css/style.css
+++ b/frontend/www/css/style.css
@@ -165,6 +165,7 @@ div#workgroup_tabs .yui-content {
 
 .yui-skin-sam .yui-dt-scrollable .yui-dt-hd {
     text-align: left;
+    position: static;
 }
 
 .yui-skin-sam .yui-navset-left .yui-nav .selected a {


### PR DESCRIPTION
This fixes a couple of things that looked wrong on the scrollable tables in the Network Status tab (and one or two other places):

* The columns in the header row were not lined up with the columns in the body rows.
* The header rows of one table would appear above the body of another table, even if the apparent overlap of the bodies of the two tables was the other way around.

The first is much closer to being correct (off by only a pixel or two now), and the second is fixed.