### PR TITLE
Adding nodes' netconf connection state

### DIFF
--- a/app/mpls/mpls_fwdctl.pl
+++ b/app/mpls/mpls_fwdctl.pl
@@ -19,6 +19,7 @@ sub core{
     my $FWDCTL = OESS::MPLS::FWDCTL->new();
     my $reaper = AnyEvent->timer( after => 3600, interval => 3600, cb => sub { $FWDCTL->reap_old_events() } );
     my $differ = AnyEvent->timer( after => 5, interval => 60, cb => sub { $FWDCTL->diff() } );
+    my $status = AnyEvent->timer( after => 10, interval => 60, cb => sub { $FWDCTL->save_mpls_nodes_status() } );
 
     Log::Log4perl->get_logger('OESS.MPLS.FWDCTL.APP')->info("Starting OESS.MPLS.FWDCTL event loop.");
     AnyEvent->condvar->recv;
@@ -67,8 +68,8 @@ sub main{
         if ($verbose) {
             $daemon = Proc::Daemon->new(
                                         pid_file => $pid_file,
-                                        child_STDOUT => '/var/log/oess/mpls.out',
-                                        child_STDERR => '/var/log/oess/mpls.log',
+                                        child_STDOUT => '/var/log/oess/mpls_fwdctl.out',
+                                        child_STDERR => '/var/log/oess/mpls_fwdctl.log',
 		);
         } else {
             $daemon = Proc::Daemon->new(

--- a/frontend/webservice/data.cgi
+++ b/frontend/webservice/data.cgi
@@ -1184,9 +1184,21 @@ sub get_all_node_status {
     my $results;
 
     my $nodes = $db->get_current_nodes();
-    
-    $results->{'results'} = $nodes;
+    foreach my $node (@{$nodes}) {
+        if(!$node->{'mpls'}){
+            next;
+        }
 
+        $mq->{'topic'} = 'MPLS.FWDCTL.Switch.' . $node->{'mgmt_addr'};
+        my $result = $mq->is_connected();
+        if (!defined $result || int($result->{'results'}->{'connected'}) == 0) {
+            $node->{'operational_state_mpls'} = 'down';
+        } else {
+            $node->{'operational_state_mpls'} = 'up';
+        }
+    }
+
+    $results->{'results'} = $nodes;
     return $results;
 }
 

--- a/frontend/webservice/data.cgi
+++ b/frontend/webservice/data.cgi
@@ -1184,20 +1184,6 @@ sub get_all_node_status {
     my $results;
 
     my $nodes = $db->get_current_nodes();
-    foreach my $node (@{$nodes}) {
-        if(!$node->{'mpls'}){
-            next;
-        }
-
-        $mq->{'topic'} = 'MPLS.FWDCTL.Switch.' . $node->{'mgmt_addr'};
-        my $result = $mq->is_connected();
-        if (!defined $result || int($result->{'results'}->{'connected'}) == 0) {
-            $node->{'operational_state_mpls'} = 'down';
-        } else {
-            $node->{'operational_state_mpls'} = 'up';
-        }
-    }
-
     $results->{'results'} = $nodes;
     return $results;
 }

--- a/frontend/webservice/monitoring.cgi
+++ b/frontend/webservice/monitoring.cgi
@@ -195,8 +195,9 @@ sub get_mpls_node_status{
     }
 
     $mq->{'topic'} = 'MPLS.FWDCTL.Switch.' . $node->{'mgmt_addr'};
-    my $result = $mq->connected();
-    $result = int($result);
+    my $result = $mq->is_connected();
+    warn Dumper($result);
+    $result = int($result->{'results'}->{'connected'});
     my $tmp;
     $tmp->{'results'} = {node => $node_name, status => $result};
     return $tmp;

--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -2051,6 +2051,8 @@ sub get_available_resources {
     my %interface_already_added;
     foreach my $interface (@$interfaces) {
         my $vlan_tag_range = $self->_validate_endpoint(interface_id => $interface->{'interface_id'}, workgroup_id => $workgroup_id );
+        my $mpls_vlan_tag_range = $self->_validate_endpoint(interface_id => $interface->{'interface_id'}, workgroup_id => $workgroup_id, type => 'mpls');
+        $vlan_tag_range .= $mpls_vlan_tag_range;
         $interface_already_added{$interface->{'interface_id'}} = 1;
         if ( $vlan_tag_range ){
             my $is_owner = 0;
@@ -7137,6 +7139,31 @@ sub provision_circuit {
     my $to_return = {"success" => 1, "circuit_id" => $circuit_id};
 
     return $to_return;
+}
+
+=head2
+
+set_mpls_node_status sets operational_state_mpls of node $node_id to
+$status which must be 'up' or 'down'.
+
+=cut
+sub set_mpls_node_status {
+    my $self = shift;
+    my $node_id = shift;
+    my $status  = shift;
+
+    if ($status ne 'up' && $status ne 'down') {
+        $self->_set_error("Node status must be 'up' or 'down'.");
+        return;
+    }
+
+    my $query = "update node set operational_state_mpls=? where node_id=?";
+    my $result = $self->_execute_query($query, [$status, $node_id]);
+    if (!defined $result) {
+        $self->_set_error("Could not update mpls node's operation state.");
+        return;
+    }
+    return $result;
 }
 
 =head2 remove_circuit

--- a/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
@@ -299,8 +299,7 @@ sub int_handler{
     
     foreach my $node (@{$self->{'db'}->get_current_nodes(mpls => 1)}){
 	$self->{'rmq_client'}->{'topic'} = "MPLS.Discovery.Switch." . $node->{'mgmt_addr'};
-	$self->{'rmq_client'}->get_interfaces( async => 1,
-					       async_callback => $self->handle_response( cb => sub { my $res = shift;
+	$self->{'rmq_client'}->get_interfaces( async_callback => $self->handle_response( cb => sub { my $res = shift;
                                                                                                      $self->{'db'}->update_node_operational_state(node_id => $node->{'node_id'}, state => 'up', protocol => 'mpls');
                                                                                                      my $status = $self->{'interface'}->process_results( node => $node->{'name'}, interfaces => $res->{'results'});
 											 }));
@@ -358,8 +357,7 @@ sub lsp_handler{
     foreach my $node (@{$self->{'db'}->get_current_nodes(mpls => 1)}){
 	$nodes{$node->{'name'}} = {'pending' => 1};
 	$self->{'rmq_client'}->{'topic'} = "MPLS.Discovery.Switch." . $node->{'mgmt_addr'};
-        $self->{'rmq_client'}->get_LSPs( async => 1,
-					 async_callback => $self->handle_response( cb => sub { my $res = shift;
+        $self->{'rmq_client'}->get_LSPs( async_callback => $self->handle_response( cb => sub { my $res = shift;
 											       $nodes{$node->{'name'}} = $res;
 											       $nodes{$node->{'name'}}->{'pending'} = 0;
 											       my $no_pending = 1;
@@ -392,8 +390,7 @@ sub isis_handler{
     foreach my $node (@{$self->{'db'}->get_current_nodes(mpls => 1)}){
 	$nodes{$node->{'short_name'}} = {'pending' => 1};
         $self->{'rmq_client'}->{'topic'} = "MPLS.Discovery.Switch." . $node->{'mgmt_addr'};
-        $self->{'rmq_client'}->get_isis_adjacencies( async => 1,
-                                        async_callback => $self->handle_response( cb => sub { my $res = shift;
+        $self->{'rmq_client'}->get_isis_adjacencies( async_callback => $self->handle_response( cb => sub { my $res = shift;
 											      $nodes{$node->{'short_name'}} = $res;
 											      $nodes{$node->{'short_name'}}->{'pending'} = 0;
 											      my $no_pending = 1;
@@ -422,8 +419,7 @@ sub device_handler{
     my $self =shift;
     foreach my $node (@{$self->{'db'}->get_current_nodes(mpls => 1)}){
         $self->{'rmq_client'}->{'topic'} = "MPLS.Discovery.Switch." . $node->{'mgmt_addr'};
-        $self->{'rmq_client'}->get_system_info( async => 1,
-						async_callback => $self->handle_response( cb => sub {
+        $self->{'rmq_client'}->get_system_info( async_callback => $self->handle_response( cb => sub {
                                                                                               my $res = shift;
                                                                                               if (defined $res->{'error'}) {
                                                                                                   my $addr = $node->{'mgmt_addr'};

--- a/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
@@ -233,9 +233,9 @@ sub _register_rpc_methods{
                                             description => "returns a list of LSPs and their details");
     $dispatcher->register_method($method);
 
-    $method = GRNOC::RabbitMQ::Method->new( name        => "connected",
+    $method = GRNOC::RabbitMQ::Method->new( name        => "is_connected",
                                             callback    => sub {
-                                                $self->connected();
+                                                return $self->connected();
                                             },
                                             description => "returns the current connected state of the device");
     $dispatcher->register_method($method);
@@ -349,7 +349,7 @@ sub echo {
 sub connected{
     my $self = shift;
     
-    return $self->{'device'}->connected();
+    return {connected => $self->{'device'}->connected()};
 }
 
 =head2 stop
@@ -445,6 +445,9 @@ sub diff {
     $self->{'logger'}->debug("Calling Switch.diff");
     $self->_update_cache();
     my $to_be_removed = $self->{'device'}->get_config_to_remove( circuits => $self->{'ckts'} );
+    if (!defined) {
+        return { error => 'Could not communicate with device.' };
+    }
     return $self->{'device'}->diff( circuits => $self->{'ckts'}, force_diff =>  $force_diff, remove => $to_be_removed);
 }
 


### PR DESCRIPTION
The connected method was conflicting with the rabbitmq clients
connected method, so it was renamed. This method was then used
in `get_mpls_node_status` and `save_mpls_nodes_status` to return the
correct netconf connection state.

Because checking a device's connection status can take some time,
we now do this on an interval and store the state in the db. This
gives the network status tab a faster load time.