### PR TITLE
Changing how update_cache communicates with Switch procs

### DIFF
--- a/frontend/webservice/provisioning.cgi
+++ b/frontend/webservice/provisioning.cgi
@@ -52,7 +52,7 @@ my $conf = GRNOC::Config->new(config_file => '/etc/oess/database.xml');
 my $db = new OESS::Database();
 
 my $mq = OESS::RabbitMQ::Client->new( topic    => 'OF.FWDCTL.RPC',
-                                      timeout  => 60 );
+                                      timeout  => 120 );
 
 my $svc = GRNOC::WebService::Dispatcher->new(method_selector => ['method', 'action']);
 
@@ -579,6 +579,7 @@ sub _send_remove_command {
 
 sub _send_mpls_update_cache{
     my %args = @_;
+
     if(!defined($args{'circuit_id'})){
         $args{'circuit_id'} = -1;
     }
@@ -605,8 +606,8 @@ sub _send_mpls_update_cache{
         warn "Error occurred while calling update_cache: Couldn't contact MPLS.FWDCTL via RabbitMQ.";
         return undef;
     }
-    if (!defined $result->{'results'}) {
-        warn "Something terrible happened with rabbitmq: " . Dumper($result);
+    if (defined $result->{'error'}) {
+        warn "Error occurred while calling update_cache: $result->{'error'}";
         return undef;
     }
     if (defined $result->{'results'}->{'error'}) {

--- a/frontend/webservice/provisioning.cgi
+++ b/frontend/webservice/provisioning.cgi
@@ -1,5 +1,8 @@
 #!/usr/bin/perl -T 
 #
+
+
+
 ##----- NDDI OESS provisioning.cgi
 ##-----
 ##----- Provides a WebAPI to allow for provisioning/decoming of circuits
@@ -970,10 +973,8 @@ sub provision_circuit {
 	    my $result = _send_mpls_remove_command( circuit_id => $circuit_id );
 
             if ( !$result ) {
-                $output->{'warning'} =
-                    "Unable to talk to fwdctl service - is it running?";
+                $output->{'warning'} = "Unable to talk to fwdctl service - is it running?";
                 $method->set_error("Unable to talk to fwdctl service - is it running?");
-
                 return;
             }
             if ( $result == 0 ) {

--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -3859,7 +3859,9 @@ sub get_circuit_details_by_name {
 }
 
 =head2 get_circuit_paths
+
     returns the circuits paths include the links that they ride over and their status
+
 =cut
 
 sub get_circuit_paths{
@@ -3872,7 +3874,11 @@ sub get_circuit_paths{
 	return;
     }
 
-    my $query = "select * from path join path_instantiation on path.path_id = path_instantiation.path_id where path.circuit_id = ? and path_instantiation.end_epoch = -1";
+    my $query = "select path.path_id, path.path_type, path.circuit_id, path.mpls_path_type, path_instantiation.* ";
+    $query .= "from path ";
+    $query .= "join path_instantiation on path.path_id = path_instantiation.path_id ";
+    $query .= "where path.circuit_id = ? and path_instantiation.end_epoch = -1 ";
+    $query .= "order by path.path_id";
 
     my $paths = $self->_execute_query($query, [$circuit_id]);
 
@@ -7984,7 +7990,7 @@ sub create_path {
 	my $result = $self->_execute_query($query, [$link_id, $path_id]);
     }
 
-    return 1;
+    return $path_id;
 }
 
 

--- a/perl-lib/OESS/lib/OESS/MPLS/Device.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device.pm
@@ -98,6 +98,19 @@ sub get_system_information{
     return;
 }
 
+=head2 get_routed_lsps
+
+See OESS::MPLS::Switch::get_routed_lsps for input and output format
+
+=cut
+
+sub get_routed_lsps{
+    my $self = shift;
+
+    $self->set_error("This device does not support get_routed_lsps");
+    return;
+}
+
 =head2 get_interfaces 
 
 =cut
@@ -128,6 +141,19 @@ sub get_LSPs{
     my $self = shift;
 
     $self->set_error("This device does not support get_LSPs");
+    return;
+}
+
+=head2 get_lsp_paths
+
+See OESS::MPLS::Switch::get_lsp_paths for input and output format
+
+=cut
+
+sub get_lsp_paths{
+    my $self = shift;
+
+    $self->set_error("This device does not support get_lsp_paths");
     return;
 }
 

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -1105,12 +1105,12 @@ sub diff {
     }
 
     my $configuration = $self->xml_configuration(\@circuits, $remove);
-    $self->{'logger'}->info(Dumper($configuration));
-
     if ($configuration eq '<configuration></configuration>') {
         $self->{'logger'}->info('No diff required at this time.');
         return FWDCTL_SUCCESS;
     }
+
+    $self->{'logger'}->debug(Dumper($configuration));
 
     if ($force_diff) {
         $self->{'logger'}->info('Force diff was initiated. Starting installation.');

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -70,6 +70,7 @@ sub disconnect{
 
     if (defined $self->{'jnx'}) {
         $self->{'jnx'}->disconnect();
+        $self->{'jnx'} = undef;
     } else {
         $self->{'logger'}->info("Device is already disconnected.");
     }
@@ -190,6 +191,113 @@ sub get_system_information{
     return {model => $model, version => $version, os_name => $os_name, host_name => $host_name, loopback_addr => $loopback_addr};
 }
 
+=head2 get_routed_lsps
+
+=cut
+
+sub get_routed_lsps{
+    my $self = shift;
+    my %args = @_;
+    my $table = $args{'table'};
+    my $circuits = $args{'circuits'};
+
+    if(!$self->{'connected'} || !defined($self->{'jnx'})){
+        $self->{'logger'}->error("Not currently connected to device");
+        return;
+    }
+
+    my $int_tag_circuit = {};
+    #first thing is to take the circuits array and parse it into an interface -> tag -> circuit lookup
+    foreach my $circuit (keys %{$circuits}){
+        my $ckt = $circuits->{$circuit};
+        foreach my $interface (@{$ckt->{'interfaces'}}){
+            $int_tag_circuit->{$interface->{'interface'}}->{$interface->{'tag'}} = $circuit;
+        }
+    }
+    
+    my $reply = $self->{'jnx'}->get_route_information( table => $table );
+
+    if($self->{'jnx'}->has_error){
+        my $error = $self->{'jnx'}->get_first_error();
+        $self->set_error($error->{'error_message'});
+        $self->{'logger'}->error("Error fetching route table information: " . $error->{'error_message'});
+        return;
+    }
+
+    my $dom = $self->{'jnx'}->get_dom();
+    my $dest_to_lsp = {};
+
+    my $path = $self->{'root_namespace'}."junos-routing";
+    my $xp = XML::LibXML::XPathContext->new( $dom );
+    $xp->registerNs('x',$dom->documentElement->namespaceURI);
+    $xp->registerNs('j',$path);
+
+    my $routes = $xp->findnodes('/x:rpc-reply/j:route-information/j:route-table/j:rt');    
+    foreach my $route (@$routes){
+	my $dest = $xp->findvalue('./j:rt-destination', $route);
+	my $protocol = $xp->findvalue('./j:rt-entry/j:protocol-name',$route);
+	my $next_hops = $xp->find('./j:rt-entry/j:nh', $route);
+
+        if ($next_hops->size() == 0) {
+            $self->{'logger'}->warn("Skipping rt-entry that has zero next hops in rt-destination $dest");
+            next;
+        }
+
+	foreach my $nh (@$next_hops){
+	    my $lsp_name = $xp->findvalue('./j:lsp-name', $nh);
+            if (!defined $lsp_name || $lsp_name eq '') {
+                # $lsp_name will probably never be undef; findvalue
+                # seems to return an emtpy string even when the
+                # lsp-name tag doesn't exist.
+                $self->{'logger'}->warn("Skipping rt-entry's next hop as it's missing an lsp-name in rt-destination $dest");
+                next;
+            }
+
+            if(!defined($dest_to_lsp->{$dest})){
+                $dest_to_lsp->{$dest} = ();
+            }
+            push(@{$dest_to_lsp->{$dest}}, $lsp_name);
+	}
+    }
+
+    my $circuit_to_lsp = {};
+
+    foreach my $dest (keys %{$dest_to_lsp}){
+        
+        #determine which type it is
+        #either the prefix, the route id or the interface name
+        #11537:3019:1:1/96
+        #172.16.0.13:3017:1:1/96
+        #xe-2/2/0.666
+        
+        my $circuit_id;
+
+        if($dest =~ /^(.*)\.(\d+)$/){
+            #ok we have an interface!
+            my $int = $1;
+            my $tag = $2;
+            #need to find the interface and vlan combo and get the circuit id!
+            if(defined($int_tag_circuit->{$int}) && defined($int_tag_circuit->{$int}->{$tag})){
+                $circuit_id = $int_tag_circuit->{$int}->{$tag};
+            }
+        }else{
+            my @parts = split(':',$dest);
+            $circuit_id = $parts[1];
+            if(!defined($circuits->{$circuit_id})){
+                #not a circuit we know about... ignoring
+                $circuit_id = undef;
+            }
+        }
+
+        next if !defined($circuit_id);
+
+        $circuit_to_lsp->{$circuit_id} = $dest_to_lsp->{$dest};
+    }
+
+    $self->{'logger'}->info(Dumper($circuit_to_lsp));
+    return $circuit_to_lsp;
+}
+
 =head2 get_interfaces
 
 returns a list of current interfaces on the device
@@ -259,6 +367,11 @@ removes a vlan via NetConf
 sub remove_vlan{
     my $self = shift;
     my $ckt = shift;
+
+    if(!$self->{'connected'} || !defined($self->{'jnx'})){
+        $self->{'logger'}->error("Not currently connected to device");
+        return;
+    }
 
     my $vars = {};
     $vars->{'circuit_name'} = $ckt->{'circuit_name'};
@@ -510,6 +623,11 @@ sub get_default_paths {
     my $self = shift;
     my $loopback_addresses = shift;
 
+    if(!$self->{'connected'} || !defined($self->{'jnx'})){
+        $self->{'logger'}->error("Not currently connected to device");
+        return;
+    }
+
     my $name   = undef;
     my $path   = undef;
     my $err    = undef;
@@ -578,7 +696,7 @@ sub xml_configuration {
         if ($ckt->{'state'} eq 'active') {
             $self->{'tt'}->process($self->{'template_dir'} . "/" . $ckt->{'ckt_type'} . "/ep_config.xml", $vars, \$xml);
         } else {
-            $self->{'tt'}->process($self->{'template_dir'} . "/" . $ckt->{'ckt_type'} . "/ep_config_delete.xml", $vars, \$xml);
+            # The remove case is now handled in get_config_to_remove
         }
 
         $xml =~ s/<configuration>//g;
@@ -685,7 +803,6 @@ sub get_config_to_remove{
     $xp->registerNs('c', 'http://xml.juniper.net/xnm/1.1/xnm');
 
     my $routing_instances = $xp->find( '/base:rpc-reply/c:configuration/c:routing-instances/c:instance');
-
     foreach my $ri (@$routing_instances){
 	my $name = $xp->findvalue( './c:name', $ri );
 	if($name =~ /^OESS/){
@@ -798,7 +915,7 @@ sub _is_active_circuit{
     my $circuits = shift;
     if(!defined($circuit_id)){
 	$self->{'logger'}->error("Unable to find the circuit ID");
-	return 1;
+	return 0;
     }
 
     if(defined($circuits->{$circuit_id}) && ($circuits->{$circuit_id}->{'state'} eq 'active')){
@@ -922,9 +1039,6 @@ sub get_device_diff {
     }
 
     my %queryargs = ('target' => 'candidate');
-    $self->{'jnx'}->lock_config(%queryargs);
-
-    %queryargs = ('target' => 'candidate');
     $queryargs{'config'} = $conf;
     my $res = $self->{'jnx'}->edit_config(%queryargs);
 
@@ -933,16 +1047,19 @@ sub get_device_diff {
         my $error = $self->{'jnx'}->get_first_error();
 	$self->set_error($error->{'error_message'});
         $self->{'logger'}->error("Error getting diff from MX: " . $error->{'error_message'});
+        $res = $self->{'jnx'}->discard_changes();
         return;
     }
 
     my $dom = $self->{'jnx'}->get_dom();
     $self->{'diff_text'} = $dom->getElementsByTagName('configuration-output')->string_value();
-    
     $res = $self->{'jnx'}->discard_changes();
-    %queryargs = ('target' => 'candidate');
-    $self->{'jnx'}->unlock_config(%queryargs);
 
+    if ($self->{'diff_text'} eq "\n") {
+        # In some cases a diff containing only an empty line may be
+        # received. This case should be ignored.
+        $self->{'diff_text'} = '';
+    }
     return $self->{'diff_text'};
 }
 
@@ -977,7 +1094,7 @@ sub diff {
 
     if(!$self->{'connected'} || !defined($self->{'jnx'})){
         $self->{'logger'}->error("Not currently connected to device");
-        return;
+        return FWDCTL_FAILURE;
     }
 
     $self->{'logger'}->info("Calling MX.diff");
@@ -988,6 +1105,7 @@ sub diff {
     }
 
     my $configuration = $self->xml_configuration(\@circuits, $remove);
+    $self->{'logger'}->info(Dumper($configuration));
 
     if ($configuration eq '<configuration></configuration>') {
         $self->{'logger'}->info('No diff required at this time.');
@@ -1064,6 +1182,10 @@ sub unit_name_available {
     my $interface_name = shift;
     my $unit_name      = shift;
 
+    if(!$self->{'connected'} || !defined($self->{'jnx'})){
+        $self->{'logger'}->error("Not currently connected to device");
+        return;
+    }
 
     if (!defined $self->{'jnx'}) {
         my $err = "Netconf connection is down.";
@@ -1158,13 +1280,20 @@ sub connect {
         return $self->{'connected'};
     }
 
-    # Configures parameters for the get_configuration method
+    # Configures parameters for several methods
     my $ATTRIBUTE = bless {}, 'ATTRIBUTE';
+    my $TOGGLE = bless { 1 => 1 }, 'TOGGLE';
+
     $self->{'jnx'}->{'methods'}->{'get_configuration'} = { format   => $ATTRIBUTE,
                                                            compare  => $ATTRIBUTE,
                                                            changed  => $ATTRIBUTE,
                                                            database => $ATTRIBUTE,
                                                            rollback => $ATTRIBUTE };
+
+    $self->{'jnx'}->{'methods'}->{'get_mpls_lsp_information'} = {
+        detail    => $TOGGLE,
+        extensive => $TOGGLE,
+    };
 
     $self->{'logger'}->info("Connected to device!");
     return $self->{'connected'};
@@ -1186,7 +1315,7 @@ sub connected {
         $self->disconnect();
     }
 
-    $self->{'logger'}->debug("Connection state is $self->{'connected'}.");
+    $self->{'logger'}->info("Connection state is $self->{'connected'}.");
     return $self->{'connected'};
 }
 
@@ -1294,11 +1423,6 @@ sub get_LSPs{
         return;
     }
 
-    if(!defined($self->{'jnx'}->{'methods'}->{'get_mpls_lsp_information'})){
-        my $TOGGLE = bless { 1 => 1 }, 'TOGGLE';
-        $self->{'jnx'}->{'methods'}->{'get_mpls_lsp_information'} = { detail => $TOGGLE};
-    }
-
     $self->{'jnx'}->get_mpls_lsp_information( detail => 1);
     my $xml = $self->{'jnx'}->get_dom();
     my $xp = XML::LibXML::XPathContext->new( $xml);
@@ -1313,6 +1437,51 @@ sub get_LSPs{
     }
 
     return \@LSPs;
+}
+
+=head2 get_lsp_paths
+
+implementation of OESS::MPLS::Device::get_lsp_paths
+
+=cut
+
+sub get_lsp_paths{
+    my $self = shift;
+
+    if(!$self->{'connected'} || !defined($self->{'jnx'})){
+        $self->{'logger'}->error('Not currently connected to device');
+        return;
+    }
+
+    my $res = $self->{'jnx'}->get_mpls_lsp_information(extensive => 1);
+    my $dom = $self->{'jnx'}->get_dom();
+
+    # Extract the link IP addresses out of the response
+    my $xp = XML::LibXML::XPathContext->new($dom);
+    warn $self->{'root_namespace'};
+    $xp->registerNs('root', $dom->documentElement->namespaceURI);
+    $xp->registerNs('r', $self->{'root_namespace'} . 'junos-routing');
+
+    my $ingress_lsps = $xp->findnodes('/root:rpc-reply/r:mpls-lsp-information/r:rsvp-session-data[r:session-type="Ingress"]/r:rsvp-session/r:mpls-lsp');
+    my $lsp_routes   = {};
+
+    foreach my $ingress_lsp (@{$ingress_lsps}) {
+        my $name  = $xp->findvalue('./r:name', $ingress_lsp);
+        my $paths = $xp->find('./r:mpls-lsp-path', $ingress_lsp);
+
+        foreach my $path (@{$paths}) {
+            if ($xp->exists('./r:path-active', $path)) {
+                my $next_hops = $xp->find('./r:explicit-route/r:address', $path);
+
+                foreach my $nh (@{$next_hops}) {
+                    push(@{$lsp_routes->{$name}}, $nh->textContent);
+                }
+            }
+        }
+    }
+
+    warn Dumper($lsp_routes);
+    return $lsp_routes;
 }
 
 sub _process_rsvp_session_data{
@@ -1599,8 +1768,7 @@ sub _edit_config{
         my $err = "$@";
         $self->set_error($err);
         $self->{'logger'}->error($err);
-        my %queryargs = ( 'target' => 'candidate' );
-        $res = $self->{'jnx'}->unlock_config(%queryargs);
+        $res = $self->{'jnx'}->unlock_config();
         return FWDCTL_FAILURE;
     }
     if($self->{'jnx'}->has_error){
@@ -1608,10 +1776,8 @@ sub _edit_config{
         my $err = "Error attempting to edit config: " . $error->{'error_message'};
         $self->set_error($err);
         $self->{'logger'}->error($err);
-	$self->{'logger'}->error(Dumper($error));
 
-        my %queryargs = ( 'target' => 'candidate' );
-        $res = $self->{'jnx'}->unlock_config(%queryargs);
+        $res = $self->{'jnx'}->unlock_config();
         return FWDCTL_FAILURE;
     }
 
@@ -1629,14 +1795,12 @@ sub _edit_config{
         $self->set_error($err);
         $self->{'logger'}->error($err);
 
-        my %queryargs = ( 'target' => 'candidate' );
-        $res = $self->{'jnx'}->unlock_config(%queryargs);
+        $res = $self->{'jnx'}->unlock_config();
         return FWDCTL_FAILURE;
     }
 
     eval {
-        my %queryargs2 = ( 'target' => 'candidate' );
-        $res = $self->{'jnx'}->unlock_config(%queryargs2);
+        $res = $self->{'jnx'}->unlock_config();
     };
     if ($@) {
         my $err = "$@";
@@ -1649,13 +1813,9 @@ sub _edit_config{
         $self->set_error($err);
         $self->{'logger'}->error($err);
 
-        my %queryargs = ( 'target' => 'candidate' );
-        $res = $self->{'jnx'}->unlock_config(%queryargs);
+        $res = $self->{'jnx'}->unlock_config();
         return FWDCTL_FAILURE;
     }
-
-    %queryargs = ( 'target' => 'candidate' );
-    $res = $self->{'jnx'}->unlock_config(%queryargs);
 
     return FWDCTL_SUCCESS;
 }

--- a/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
@@ -57,6 +57,9 @@ use Log::Log4perl;
 
 use AnyEvent;
 
+use constant MPLS_TABLE => 'mpls.0';
+use constant VPLS_TABLE => 'bgp.l2vpn.0';
+
 =head2 new
     instantiates a new OESS::MPLS::Discovery object, which intern creates new 
     instantiations of 
@@ -108,6 +111,10 @@ sub new{
 							 topic => 'MPLS.Discovery');
     
     die if(!defined($self->{'rmq_client'}));
+
+    # set up some sequence numbers so path detection handles out-of-order responses sanely
+#    $self->{'path_sequence'} = 0;
+#    $self->{'path_node_latest'} = {};
 
     #setup the timers
     $self->{'device_timer'} = AnyEvent->timer( after => 10, interval => 60, cb => sub { $self->device_handler(); });
@@ -211,6 +218,7 @@ sub make_baby{
 
     my %args;
     $args{'id'} = $id;
+    $args{'share_file'} = '/var/run/oess/mpls_share.'. $id;
     $args{'rabbitMQ_host'} = $self->{'db'}->{'rabbitMQ'}->{'host'};
     $args{'rabbitMQ_port'} = $self->{'db'}->{'rabbitMQ'}->{'port'};
     $args{'rabbitMQ_user'} = $self->{'db'}->{'rabbitMQ'}->{'user'};
@@ -324,25 +332,66 @@ sub path_handler {
         return 0;
     }
 
-    my @loopback_addrs;
+#    my $curr_path_sequence = $self->{'path_sequence'};
+#    $self->{'path_sequence'} += 1;
 
+    # Map from circuit ID to the list of LSPs associated with the circuit
+    my %circuit_lsps;
+    # Map from LSP name to the list of links currently used by the LSP
+    # (or rather, for each link, it has the IP address of an endpoint)
+    my %lsp_paths;
+
+    my $cv = AnyEvent->condvar;
+    $cv->begin(sub {
+                   #now that we have all of the circuit LSPs and all of the LSP paths
+                   #turn this into updates to the OESS DB!
+                   $self->{'path'}->process_results(
+                       circuit_lsps => \%circuit_lsps,
+                       lsp_paths    => \%lsp_paths
+                   );
+
+                   $self->{'logger'}->error(Dumper(\%circuit_lsps));
+                   $self->{'logger'}->error(Dumper(\%lsp_paths));
+               });
+
+    # For each node, get the list of LSPs, and the associated circuits and paths
     foreach my $node (@{$nodes}) {
-        if (!defined $node->{'loopback_address'}) {
-            next;
-        }
-        push(@loopback_addrs, $node->{'loopback_address'});
-    }
-    
-    foreach my $node (@{$nodes}){ 
         $self->{'rmq_client'}->{'topic'} = "MPLS.Discovery.Switch." . $node->{'mgmt_addr'};
-        $self->{'rmq_client'}->get_default_paths( loopback_addresses => \@loopback_addrs,
-                                                  async_callback     => sub {
-                                                      my $res = shift;
-                                                      warn "Processing results\n";
-                                                      $self->{'path'}->process_results( paths => $res->{'results'}, node_id => $node->{'node_id'} );
-                                                      return 1;
-                                                  } );
+
+        foreach my $table (MPLS_TABLE, VPLS_TABLE) {
+            $cv->begin();
+            $self->{'rmq_client'}->get_routed_lsps(
+                table          => $table,
+                async_callback => sub {
+                    my $res = shift;
+                    if(!defined($res->{'error'})){
+                        foreach my $ckt (keys %{$res->{'results'}}){
+                            $circuit_lsps{$ckt} = [] if !defined($circuit_lsps{$ckt});
+                            push @{$circuit_lsps{$ckt}}, @{$res->{'results'}->{$ckt}};
+                        }
+                    }
+
+                    $cv->end;
+                });
+        }
+
+        $cv->begin();
+        $self->{'rmq_client'}->get_lsp_paths(
+            async_callback => sub {
+                my $res = shift;
+                if(!defined($res->{'error'})){
+                    my %paths = %{$res->{'results'}};
+                    foreach my $lsp (keys %paths){
+                        $lsp_paths{$lsp} = [] if !defined($lsp_paths{$lsp});
+                        push @{$lsp_paths{$lsp}}, @{$paths{$lsp}};
+                    }
+                }
+
+                $cv->end;
+            });
     }
+
+    $cv->end;
 }
 
 =head2 lsp_handler

--- a/perl-lib/OESS/lib/OESS/MPLS/Discovery/Paths.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Discovery/Paths.pm
@@ -101,7 +101,6 @@ sub _process_paths{
        my @ckt_path1 = map { $ip_links{$_} } @ckt_path0;
        my @ckt_path2 = uniq @ckt_path1; # list of link_ids making up the circuit, without duplication
        my @ckt_path  = map { $links_by_id{$_} } @ckt_path2;
-       $self->{'logger'}->info(Dumper(@ckt_path));
 
        my $ckt = OESS::Circuit->new(db => $self->{'db'}, circuit_id => $circuit_id);
        $ckt->update_mpls_path(links => \@ckt_path);

--- a/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
@@ -465,12 +465,14 @@ sub diff {
 
     $self->{'logger'}->debug("Calling Switch.diff");
     $self->_update_cache();
+
     my $to_be_removed = $self->{'device'}->get_config_to_remove( circuits => $self->{'ckts'} );
     if (!defined $to_be_removed) {
-        return { error => 'Could not communicate with device.' };
+        $self->{'logger'}->error('Could not communicate with device.');
+        return FWDCTL_FAILURE;
     }
 
-    return $self->{'device'}->diff( circuits => $self->{'ckts'}, force_diff =>  $force_diff, remove => $to_be_removed);
+    return $self->{'device'}->diff(circuits => $self->{'ckts'}, force_diff =>  $force_diff, remove => $to_be_removed);
 }
 
 =head2 get_diff_text


### PR DESCRIPTION
Previous calls to update_cache were timing out. By switching
to the more common 'begin' and 'end' pattern I've elimated this
issue.

When verifying the Switch->update_cache method, additional error
handling was added.

To be merged after #398 