### PR TITLE
Adding param to get_configuration as required by new Junos version

### DIFF
--- a/perl-lib/OESS/lib/OESS/MPLS/FWDCTL.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/FWDCTL.pm
@@ -985,15 +985,13 @@ sub get_diff_text {
     $self->{'fwdctl_events'}->get_diff_text(
 	async_callback => sub {
             my $response = shift;
-            
+
             if (defined $response->{'error'}) {
                 &$error_cb({error => $response->{'error'}, status => FWDCTL_FAILURE});
             } else {
                 &$success_cb( {status => FWDCTL_SUCCESS, results => [ $response->{'results'} ]});
-                #$event->{'results'} = [ $response->{'results'} ];
-                #$event->{'status'} = FWDCTL_SUCCESS;
             }
-	} );
+	});
 }
 
 =head2 get_ckt_object

--- a/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
@@ -486,6 +486,7 @@ sub diff {
         $self->{'logger'}->error('Could not communicate with device.');
         return FWDCTL_FAILURE;
     }
+    $self->{'logger'}->debug("Config to remove: " . Dumper($to_be_removed));
 
     return $self->{'device'}->diff(circuits => $self->{'ckts'}, force_diff =>  $force_diff, remove => $to_be_removed);
 }
@@ -502,7 +503,12 @@ sub get_diff_text {
     $self->{'logger'}->debug("Calling Switch.get_diff_text");
     $self->_update_cache();
     my $to_be_removed = $self->{'device'}->get_config_to_remove( circuits => $self->{'ckts'} );
-    return $self->{'device'}->get_diff_text(circuits => $self->{'ckts'}, remove => $to_be_removed);
+    my $diff = $self->{'device'}->get_diff_text(circuits => $self->{'ckts'}, remove => $to_be_removed);
+    if (!defined $diff) {
+        return 'No diff required at this time.';
+    }
+
+    return $diff;
 }
 
 =head2 get_default_paths


### PR DESCRIPTION
According to docs format isn't considered when used with compare.
However in 15.1F6-S6.4 it is; I would expect this to continue
in later Junos versions.