### PR TITLE
replacing error string with error hash

### DIFF
--- a/frontend/webservice/workgroup_manage.cgi
+++ b/frontend/webservice/workgroup_manage.cgi
@@ -45,12 +45,12 @@ $| = 1;
 sub main {
 
     if ( !$db ) {
-        send_json( { "error" => "Unable to connect to database." } );
+        send_json({ "error" => "Unable to connect to database." });
         exit(1);
     }
 
     if ( !$svc ){
-	send_json( {"error" => "Unable to access GRNOC::WebService" });
+	send_json({ "error" => "Unable to access GRNOC::WebService" });
 	exit(1);
     }
 
@@ -60,12 +60,12 @@ sub main {
     
  
     if ($user->{'status'} eq 'decom') {
-	send_json("error");
+	send_json({ "error" => "error" });
 	exit(1);
     }
     
     if ($user->{'type'} eq 'read-only') {
-	send_json("Error: you are a readonly user");
+	send_json({ "error" => "Error: you are a readonly user" });
 	return;
     }
 

--- a/perl-lib/OESS/lib/OESS/MPLS/FWDCTL.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/FWDCTL.pm
@@ -985,15 +985,13 @@ sub get_diff_text {
     $self->{'fwdctl_events'}->get_diff_text(
 	async_callback => sub {
             my $response = shift;
-            
+
             if (defined $response->{'error'}) {
                 &$error_cb({error => $response->{'error'}, status => FWDCTL_FAILURE});
             } else {
                 &$success_cb( {status => FWDCTL_SUCCESS, results => [ $response->{'results'} ]});
-                #$event->{'results'} = [ $response->{'results'} ];
-                #$event->{'status'} = FWDCTL_SUCCESS;
             }
-	} );
+	});
 }
 
 =head2 get_ckt_object

--- a/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
@@ -486,6 +486,7 @@ sub diff {
         $self->{'logger'}->error('Could not communicate with device.');
         return FWDCTL_FAILURE;
     }
+    $self->{'logger'}->debug("Config to remove: " . Dumper($to_be_removed));
 
     return $self->{'device'}->diff(circuits => $self->{'ckts'}, force_diff =>  $force_diff, remove => $to_be_removed);
 }
@@ -502,7 +503,12 @@ sub get_diff_text {
     $self->{'logger'}->debug("Calling Switch.get_diff_text");
     $self->_update_cache();
     my $to_be_removed = $self->{'device'}->get_config_to_remove( circuits => $self->{'ckts'} );
-    return $self->{'device'}->get_diff_text(circuits => $self->{'ckts'}, remove => $to_be_removed);
+    my $diff = $self->{'device'}->get_diff_text(circuits => $self->{'ckts'}, remove => $to_be_removed);
+    if (!defined $diff) {
+        return 'No diff required at this time.';
+    }
+
+    return $diff;
 }
 
 =head2 get_default_paths


### PR DESCRIPTION
Passing a string to send_json resulted in a crash. Passing a hash
ensures a valid json encoding.

to be merged after #402 