### PR TITLE
Adding private config mode

### DIFF
--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -1112,6 +1112,7 @@ sub get_device_diff {
     my %queryargs = ('target' => 'candidate');
     $queryargs{'config'} = $conf;
 
+    my $ok = $self->lock();
 
     my $res = $self->{'jnx'}->edit_config(%queryargs);
     if (!defined $res) {
@@ -1136,6 +1137,8 @@ sub get_device_diff {
 	$self->set_error($error->{'error_message'});
         $self->{'logger'}->error("Error getting diff from MX: " . $error->{'error_message'});
         $res = $self->{'jnx'}->discard_changes();
+
+        $ok = $self->unlock();
         return;
     }
 
@@ -1148,6 +1151,8 @@ sub get_device_diff {
         # received. This case should be ignored.
         $self->{'diff_text'} = '';
     }
+
+    $ok = $self->unlock();
     return $self->{'diff_text'};
 }
 


### PR DESCRIPTION
When working directly on the candidate config, any changes made in
private mode (by an admin for example) cannot be merged. This change
makes our edits use the private configuration mode; If everyone is
using this mode we can have multiple configurations sessions in use at
one time.