### PR TITLE
Passing mpls as an option to get_circuits_on_link

### DIFF
--- a/frontend/webservice/admin/admin.cgi
+++ b/frontend/webservice/admin/admin.cgi
@@ -945,7 +945,10 @@ sub is_ok_to_decom{
 
     my $link_details = $db->get_link( link_id => $args->{'link_id'}{'value'} );
 
-    my $circuits = $db->get_circuits_on_link( link_id => $link_details->{'link_id'} );
+    my $circuits = $db->get_circuits_on_link(
+        link_id => $link_details->{'link_id'},
+        mpls    => $link_details->{'mpls'}
+    );
     $results->{'results'}->[0]->{'active_circuits'} = $circuits;
 
 

--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -5082,7 +5082,10 @@ sub insert_node_in_path{
     }
 
     #ok first decom the old
-    my $circuits = $self->get_circuits_on_link( link_id => $link_details->{'link_id'});
+    my $circuits = $self->get_circuits_on_link(
+        link_id => $link_details->{'link_id'},
+        mpls    => $link_details->{'mpls'}
+    );
 
     $self->decom_link(link_id => $link_details->{'link_id'});
 


### PR DESCRIPTION
By default get_circuits_on_link only returns openflow circuits on a link. Since we ommitted the mpls param, get_circuits_on_link returned zero circuits when called against an mpls link.