### PR TITLE
Fixing issue where flow count was always reported as zero

### DIFF
--- a/frontend/webservice/monitoring.cgi
+++ b/frontend/webservice/monitoring.cgi
@@ -226,6 +226,11 @@ sub get_rules_on_node{
     $mq->{'topic'} = 'OF.FWDCTL.RPC';
     my $result = $mq->rules_per_switch(dpid => int($node->{'dpid'}));
     warn Data::Dumper::Dumper($result);
+    if (defined $result->{'error'}) {
+        $method->set_error($result->{'error'});
+        return;
+    }
+
     $result = int($result->{'results'}->{'rules_on_switch'});
 
     my $tmp;

--- a/perl-lib/OESS/lib/OESS/FWDCTL/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/FWDCTL/Switch.pm
@@ -208,6 +208,16 @@ sub new {
                                             topic       => "OF.FWDCTL.event" );
     $dispatcher->register_method($method);
 
+    $method = GRNOC::RabbitMQ::Method->new(
+        name        => "get_flows",
+        description => "Number of flows installed on this device",
+        callback    => sub {
+            return {flows => $self->{'flows'}};
+        }
+    );
+    $dispatcher->register_method($method);
+
+
     #--- set a default discovery vlan that can be overridden later if needed.
     $self->{'settings'}->{'discovery_vlan'} = -1;
 


### PR DESCRIPTION
An old catch all callback used to be intercepting this value. Since
that callback is no longer used, I've added a new way to access this
data.