### PR TITLE
Frontend: remove dependency on OSCARS::Client

### DIFF
--- a/frontend/oess-frontend.spec
+++ b/frontend/oess-frontend.spec
@@ -20,7 +20,7 @@ Requires: nddi-tiles
 Requires: perl-Crypt-SSLeay
 Requires: xmlsec1, xmlsec1-openssl
 
-Requires: perl-OESS >= 1.2.0, perl-OSCARS-Client >= 1.2.0
+Requires: perl-OESS >= 1.2.0
 
 Requires: perl(strict), perl(warnings)
 Requires: perl(AnyEvent)


### PR DESCRIPTION
Since we yanked remote.cgi out, the frontend no longer needs OSCARS::Client. This allows us to not package the module any longer.