### PR TITLE
Multi-link popup panel: remove from DOM when closing ISSUE=4527

### DIFF
--- a/frontend/www/js_utilities/multilink_panel.js
+++ b/frontend/www/js_utilities/multilink_panel.js
@@ -56,14 +56,14 @@ var get_multilink_panel = function(container_id, options){
         var link = $('#'+this.container_id+'_link_selector').val();
         if(link == "") link = null;
         options.on_change({ link: link });
-        panel.hide();
+        panel.destroy();
     }, false, { container_id: container_id });
 
     //set up cancel button
     var cancel_panel_button = new YAHOO.widget.Button(container_id+'_cancel');
     cancel_panel_button.set('label','Cancel');
     cancel_panel_button.on('click',function(){
-        panel.hide();
+        panel.destroy();
     });
 
     return panel;


### PR DESCRIPTION
Simply hiding the panel (as was done prior to this commit) causes problems when we want to use a multi-link panel again, as the way the app does things, it generates a new `<div>` with the exact same `id`. Duplicate nodes with the same `id` lead to the panel not working (to the point of not displaying, even), at least on Firefox.

This change has been tested with Firefox and Chrome.