### PR TITLE
Adding preselcted link to multi-link selection panel

### DIFF
--- a/frontend/www/js_utilities/multilink_panel.js
+++ b/frontend/www/js_utilities/multilink_panel.js
@@ -28,7 +28,7 @@ var get_multilink_panel = function(container_id, options){
     var link_options = "<option value=''>Select Link</option>";
     for( var i = 0; i < options.links.length; i++ ){
         var link = options.links[i];
-        if( (options.already_used_check) && is_already_used(link.link_name)) continue;
+        //if( (options.already_used_check) && is_already_used(link.link_name)) continue;
         //if( (options.hide_down_links) && (link.state == "down") ) continue;
         //if(is_already_used(link.link_name)) {
         //    link_options += "class='disabled-result' "; 


### PR DESCRIPTION
Previously, if a link was already selected, it would not be displayed
in the multi-link selection box. This meant that deselecting a link
accross a multi-link adjacency was impossible.