### PR TITLE
Adding diffing on strict paths

### DIFF
--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -989,10 +989,8 @@ sub get_config_to_remove{
 
 		foreach my $path_list (@$path_lists) {
 		    my $path_list_name = $xp->findvalue('./c:name', $path_list);
-		    $self->{'logger'}->info('===' . $path_list_name);
 
 		    if (!defined $strict_path->{$path_list_name}) {
-			$self->{'logger'}->info("===Adding $path_list_name to path-list delete");
 		     	$path_list_dels .= "<path-list operation='delete'><name>" . $path_list_name . "</name></path-list>";
 		    }
 		}


### PR DESCRIPTION
Diffing on strict paths was broken; If a mpls path on a device was
modified OESS was unable to repair the change. This change allows OESS
to detect extra, missing, and incorrect hops and then correct them.