### PR TITLE
Re-adding diffing on strict paths

### DIFF
--- a/perl-lib/OESS/lib/OESS/Circuit.pm
+++ b/perl-lib/OESS/lib/OESS/Circuit.pm
@@ -1678,8 +1678,12 @@ sub get_mpls_hops{
 	my $node_a = $link->{'node_a'};
 	my $node_z = $link->{'node_z'};
 
-	$ip_address{$node_a}{$node_z} = $link->{'ip_z'};
-	$ip_address{$node_z}{$node_a} = $link->{'ip_a'};
+        # When using link based ip addresses
+        # $ip_address{$node_a}{$node_z} = $link->{'ip_z'};
+        # $ip_address{$node_z}{$node_a} = $link->{'ip_a'};
+
+        $ip_address{$node_a}{$node_z} = $nodes{$node_a}->{'loopback_address'};
+        $ip_address{$node_z}{$node_a} = $nodes{$node_z}->{'loopback_address'};
     }
 
     #verify that our start/end are endpoints

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -1034,7 +1034,29 @@ sub get_config_to_remove{
 	    my $circuit_id = $1;
             if (!$self->_is_active_circuit($circuit_id, $circuits)) {
                 $path_dels .= "<path operation='delete'><name>" . $name . "</name></path>";
-	    }
+	    } else {
+                # Active circuits with a 'strict' or manually defined
+                # path should check their path for extra hops.
+                my $strict_path = $self->_get_strict_path($circuit_id, $circuits);
+                if (!defined $strict_path) {
+                    next;
+                }
+
+                my $path_list_dels = "";
+                my $path_lists = $xp->find('./c:path-list', $path);
+
+                foreach my $path_list (@$path_lists) {
+                    my $path_list_name = $xp->findvalue('./c:name', $path_list);
+
+                    if (!defined $strict_path->{$path_list_name}) {
+                        $path_list_dels .= "<path-list operation='delete'><name>" . $path_list_name . "</name></path-list>";
+                    }
+                }
+
+                if ($path_list_dels ne '') {
+                    $path_dels .= "<path><name>" . $name . "</name>" . $path_list_dels . "</path>";
+                }
+            }
         }
     }
 

--- a/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2CCC/ep_config.xml
+++ b/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2CCC/ep_config.xml
@@ -44,10 +44,6 @@
           <strict />
         </path-list>
           [% END %]
-	[% ELSE %]
-	<path-list>
-	  <name>[% dest %]</name>
-	</path-list>
         [% END %]
       </path>
       [% END %]


### PR DESCRIPTION
Diffing on strict paths was broken; If a mpls path on a device was
modified OESS was unable to repair the change. This change allows OESS
to detect extra, missing, and incorrect hops and then correct them.

This change was removed prior to the last release. It's now being
pulled back in to fix incorrectly defined static paths, and migrate to
loopback based link discovery.