### PR TITLE
Disconnecting ssh from devices using wrong fw version

### DIFF
--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -1564,6 +1564,7 @@ sub verify_connection{
     }
 
     $self->{'logger'}->error("Network OS $sysinfo->{'os_name'} version $sysinfo->{'version'} on the $sysinfo->{'model'} is not supported.");
+    $self->disconnect();
     return 0;
 }
 


### PR DESCRIPTION
When a device with an unsupported firmware version was detected we
allowed the connection to remain established. This made it difficult
to realize what was going on. We now disconnect the device if we
discover an unsupported firmware version. Fixes #503