### PR TITLE
removing encodeURIComponent before passing to web api

### DIFF
--- a/frontend/webservice/vrf.cgi
+++ b/frontend/webservice/vrf.cgi
@@ -208,7 +208,7 @@ sub provision_vrf{
         return;
     }
 
-    $model->{'description'} = $params->{'name'}{'value'};
+    $model->{'description'} = $params->{'description'}{'value'};
     $model->{'prefix_limit'} = $params->{'prefix_limit'}{'value'};
 
     $model->{'workgroup_id'} = $params->{'workgroup_id'}{'value'};

--- a/frontend/www/js_templates/api/vrf.js
+++ b/frontend/www/js_templates/api/vrf.js
@@ -33,8 +33,8 @@ async function provisionVRF(workgroupID, name, description, endpoints, provision
 
   let form = new FormData();
   form.append('method', 'provision');
-  form.append('name', encodeURIComponent(name));
-  form.append('description', encodeURIComponent(description));
+  form.append('name', name);
+  form.append('description', description);
   form.append('local_asn', 1);
   form.append('workgroup_id', workgroupID);
   form.append('provision_time', provisionTime);
@@ -76,7 +76,7 @@ async function provisionVRF(workgroupID, name, description, endpoints, provision
         return null;
     }
 
-    if (typeof data.results.success !== undefined && data.results.success === 1) {
+    if (typeof data.results.success !== 'undefined' && typeof data.results.vrf_id !== 'undefined') {
       return parseInt(data.results.vrf_id);
     }
   } catch(error) {


### PR DESCRIPTION
This call was causing spaces to be encoded as %20 and these were being
stored in the db. Fixes #567 