### PR TITLE
Fixing issues that caused remove vrf to fail

### DIFF
--- a/frontend/webservice/vrf.cgi
+++ b/frontend/webservice/vrf.cgi
@@ -298,20 +298,18 @@ sub remove_vrf{
         return {success => 0};
     }
 
-
-
     my $result;
     if(!$user->in_workgroup( $wg)){
         $method->set_error("User " . $ENV{'REMOTE_USER'} . " is not in workgroup");
         return {success => 0};
     }
 
-    $vrf->decom(user_id => $user->user_id());
-
     my $res = vrf_del( method => $method, vrf_id => $vrf_id);
     $res->{'vrf_id'} = $vrf_id;
-    return {results => $res};
 
+    $vrf->decom(user_id => $user->user_id());
+
+    return {results => $res};
 }
 
 sub vrf_add{

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -861,10 +861,11 @@ sub remove_vrf{
     $vars->{'vrf_name'} = $vrf->{'vrf_name'};
     $vars->{'interfaces'} = [];
     foreach my $i (@{$vrf->{'interfaces'}}) {
-        push (@{$vars->{'interfaces'}}, { name => $i->{'interface'},
+        push (@{$vars->{'interfaces'}}, { name => $i->{'name'},
                                           tag  => $i->{'tag'}
 	      });
     }
+
     $vars->{'vrf_id'} = $vrf->{'vrf_id'};
     $vars->{'switch'} = {name => $self->{'name'}, loopback => $self->{'loopback_addr'}};
 


### PR DESCRIPTION
The device update method checks that decom'd circuits are
ignored. Since we were updating the db prior to calling this function
the l3vpn was never removed from the device.