### PR TITLE
adding inner_vlan param to is_vlan_tag_available

### DIFF
--- a/frontend/webservice/provisioning.cgi
+++ b/frontend/webservice/provisioning.cgi
@@ -916,7 +916,8 @@ sub provision_vrf {
     my @nodes;
     my @interfaces;
     my @vlans;
-    
+    my @inner_vlans;
+
     my @endpoints;
     foreach my $ep (@$endpoints){
 	warn "Endpoints: $ep\n";
@@ -932,6 +933,7 @@ sub provision_vrf {
         push(@nodes, $endpoint->{'node'});
         push(@interfaces, $endpoint->{'interface'});
         push(@vlans, $endpoint->{'tag'});
+        push(@inner_vlans, $endpoint->{'inner_tag'});
     }
     
     warn Dumper(@endpoints);
@@ -946,8 +948,9 @@ sub provision_vrf {
         backup_links => [],
         nodes => \@nodes,
         interfaces => \@interfaces,
-        vlans => \@vlans
-    );    
+        vlans => \@vlans,
+        inner_vlans => \@inner_vlans
+    );
 
     if (!$status){
         warn "Couldn't validate circuit: " . $err;
@@ -1122,7 +1125,8 @@ sub provision_circuit {
 	backup_links => $backup_links,
 	nodes => $nodes,
 	interfaces => $interfaces,
-        vlans => $tags
+        vlans => $tags,
+        inner_vlans => $inner_tags
     );
     if (!$status){
 	warn "Couldn't validate circuit: " . $err;

--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -6709,6 +6709,7 @@ sub validate_circuit {
     my $nodes        = $args{'nodes'};
     my $interfaces   = $args{'interfaces'};
     my $vlans        = $args{'vlans'};
+    my $inner_vlans  = $args{'inner_vlans'} || [];
 
     my $type;
 
@@ -6726,7 +6727,11 @@ sub validate_circuit {
         
         my $interface = $self->get_interface( interface_id => $interface_id);
 
-        my $res = $self->is_external_vlan_available_on_interface( interface_id => $interface_id, vlan => $vlans->[$i]);
+        my $res = $self->is_external_vlan_available_on_interface(
+            interface_id => $interface_id,
+            vlan => $vlans->[$i],
+            inner_vlan => $inner_vlans->[$i]
+        );
         warn Dumper($res);
         if(!defined($type)){
             $type = $res->{'type'};

--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -6732,7 +6732,10 @@ sub validate_circuit {
             vlan => $vlans->[$i],
             inner_vlan => $inner_vlans->[$i]
         );
-        warn Dumper($res);
+        if (!$res->{status}) {
+            return (0, "VLAN $vlans->[$i] $inner_vlans->[$i] is not available on $nodes->[$i] $interfaces->[$i].");
+        }
+
         if(!defined($type)){
             $type = $res->{'type'};
         }else{
@@ -9221,7 +9224,8 @@ sub validate_endpoints {
         }
 
         # need to check to see if this external vlan is open on this interface first
-        if (! $self->is_external_vlan_available_on_interface(vlan => $vlan, interface_id => $interface_id, circuit_id => $circuit_id) ){
+        my $is_avail = $self->is_external_vlan_available_on_interface(vlan => $vlan, interface_id => $interface_id, circuit_id => $circuit_id);
+        if (!$is_avail->{'status'}) {
             $self->_set_error("Vlan '$vlan' is currently in use by another circuit on interface '$interface' on endpoint '$node'");
             return;
         }

--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -670,6 +670,7 @@ sub is_external_vlan_available_on_interface {
     my %args = @_;
 
     my $vlan_tag     = $args{'vlan'};
+    my $inner_vlan_tag = $args{'inner_vlan'};
     my $interface_id = $args{'interface_id'};
     my $circuit_id = $args{'circuit_id'};
 
@@ -689,9 +690,10 @@ sub is_external_vlan_available_on_interface {
                 " on circuit.circuit_id = circuit_edge_interface_membership.circuit_id " .
                 " where circuit_edge_interface_membership.interface_id = ? " .
                 " and circuit_edge_interface_membership.extern_vlan_id = ? " .
+                " and circuit_edge_interface_membership.inner_tag = ? " .
                 " and circuit_edge_interface_membership.end_epoch = -1";
 
-    my $result = $self->_execute_query($query, [$interface_id, $vlan_tag]);
+    my $result = $self->_execute_query($query, [$interface_id, $vlan_tag, $inner_vlan_tag]);
     if (!defined $result) {
         $self->_set_error("Internal error while finding available external vlan tags.");
         return;
@@ -705,8 +707,8 @@ sub is_external_vlan_available_on_interface {
         }
     }
 
-    $query = "select vrf.vrf_id from vrf join vrf_ep on vrf.vrf_id = vrf_ep.vrf_id where vrf.state='active' and vrf_ep.interface_id=? and vrf_ep.tag=?";
-    my $result2 = $self->_execute_query($query, [$interface_id, $vlan_tag]);
+    $query = "select vrf.vrf_id from vrf join vrf_ep on vrf.vrf_id = vrf_ep.vrf_id where vrf.state='active' and vrf_ep.interface_id=? and vrf_ep.tag=? and vrf_ep.inner_tag=?";
+    my $result2 = $self->_execute_query($query, [$interface_id, $vlan_tag, $inner_vlan_tag]);
     if (!defined $result2) {
         $self->_set_error("Internal error while finding available vrf vlan tags");
         return;

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -841,6 +841,11 @@ sub add_vrf{
             $unit = ((($a+$b+1)*($a+$b))/2)+$b+5000;
         }
 
+        if ($self->unit_name_available($i->{'name'}, $unit) == 0) {
+            $self->{'logger'}->error("Unit $unit is not available on $i->{'name'}");
+            return FWDCTL_FAILURE;
+        }
+
         push (@{$vars->{'interfaces'}}, { name => $i->{'name'},
                                           inner_tag => $i->{'inner_tag'},
                                           tag  => $i->{'tag'},
@@ -856,11 +861,6 @@ sub add_vrf{
     $vars->{'prefix_limit'} = $vrf->{'prefix_limit'};
 
     $self->{'logger'}->error("VARS: " . Dumper($vars));
-
-    if ($self->unit_name_available($vars->{'interface'}->{'name'}, $vars->{'tag'}) == 0) {
-        $self->{'logger'}->error("Unit $vars->{'tag'} is not available on $vars->{'interface'}->{'name'}");
-        return FWDCTL_FAILURE;
-    }
 
     my $output;
     my $ok = $self->{'tt'}->process($self->{'template_dir'} . "/L3VPN/ep_config.xml", $vars, \$output);
@@ -1410,7 +1410,7 @@ sub _is_circuit_on_port{
         }
 
         if($int->{'interface'} eq $port && $unit eq $vlan){
-            $self->{'logger'}->error("Interface $int->{'interface'}.$unit is in circuit $circuit_id.");
+            $self->{'logger'}->debug("Interface $int->{'interface'}.$unit is in circuit $circuit_id.");
             return 1;
         }
     }

--- a/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
@@ -183,9 +183,9 @@ sub _register_rpc_methods{
                                   pattern => $GRNOC::WebService::Regex::NUMBER_ID);
     $dispatcher->register_method($method);
     
-    my $method = GRNOC::RabbitMQ::Method->new( name => "add_vrf",
-                                               description => "adds a vrf for this switch",
-					       callback => sub { return {status => $self->add_vrf(@_) }});
+    $method = GRNOC::RabbitMQ::Method->new( name => "add_vrf",
+                                            description => "adds a vrf for this switch",
+                                            callback => sub { return {status => $self->add_vrf(@_) }});
     
     $method->add_input_parameter( name => "vrf_id",
                                   description => "vrf_id to be added",
@@ -193,9 +193,9 @@ sub _register_rpc_methods{
                                   pattern => $GRNOC::WebService::Regex::NUMBER_ID);
     $dispatcher->register_method($method);
     
-    my $method = GRNOC::RabbitMQ::Method->new( name => "remove_vrf",
-                                               description => "removes a vrf from this switch",
-                                               callback => sub { return {status => $self->remove_vrf(@_) }});
+    $method = GRNOC::RabbitMQ::Method->new( name => "remove_vrf",
+                                            description => "removes a vrf from this switch",
+                                            callback => sub { return {status => $self->remove_vrf(@_) }});
 
     $method->add_input_parameter( name => "vrf_id",
                                   description => "vrf_id to be removed",


### PR DESCRIPTION
inner_vlan param is optional and defaults to undef. When provided, the
check will validate against 802.1ad (qnq tagged) endpoints. If not
provided, the check will only validate against 802.1q tagged
endpoints.

Fixes #596 and fixes #597 