### PR TITLE
Entity acls changes

### DIFF
--- a/frontend/webservice/command.cgi
+++ b/frontend/webservice/command.cgi
@@ -28,8 +28,7 @@ $method->add_input_parameter(
     name => "type",
     pattern => $GRNOC::WebService::Regex::TEXT,
     required => 0,
-    description => "Type of commands to get",
-    default => 'l3vpn'
+    description => "Type of commands to get"
 );
 $svc->register_method($method);
 

--- a/frontend/webservice/entity.cgi
+++ b/frontend/webservice/entity.cgi
@@ -83,7 +83,7 @@ sub register_ro_methods{
         description     => "The workgroup id to find the ACLs for the entity"   );
 
     $method->add_input_parameter(
-        name            => 'circuit_id_id',
+        name            => 'circuit_id',
         pattern         => $GRNOC::WebService::Regex::INTEGER,
         required        => 0,
         description     => "The workgroup id to find the ACLs for the entity"   );

--- a/frontend/webservice/interface.cgi
+++ b/frontend/webservice/interface.cgi
@@ -160,6 +160,7 @@ sub get_workgroup_interfaces{
     my $method = shift;
     my $params = shift;
     my $workgroup_id = $params->{'workgroup_id'}{'value'};
+    my $vlan = $params->{'vlan'}{'value'};
 
     my $workgroup = OESS::Workgroup->new( workgroup_id => $workgroup_id, db => $db);
     my $interfaces = $workgroup->interfaces();

--- a/frontend/webservice/interface.cgi
+++ b/frontend/webservice/interface.cgi
@@ -7,7 +7,7 @@ use GRNOC::WebService::Method;
 use GRNOC::WebService::Dispatcher;
 use OESS::DB;
 use OESS::Interface;
-
+use OESS::VRF;
 
 my $db = OESS::DB->new();
 my $svc = GRNOC::WebService::Dispatcher->new();
@@ -32,7 +32,16 @@ sub register_ro_methods{
                                   required => 1,
                                   description => 'Workgroup ID to fetch details'
         );
+
+    $method->add_input_parameter( name => 'vrf_id',
+                                  patern => $GRNOC::WebService::Regex::INTEGER,
+                                  required => 0,
+                                  description => 'VRF ID of the VRF being edited (if one is being edited)');
     
+    $method->add_input_parameter( name => 'circuit_id',
+                                  patern => $GRNOC::WebService::Regex::INTEGER,
+                                  required => 0,
+                                  description => 'VRF ID of the VRF being edited (if one is being edited)');
 
     $svc->register_method($method);
 
@@ -73,17 +82,41 @@ sub get_available_vlans{
     my $interface_id = $params->{'interface_id'}{'value'};
     my $workgroup_id = $params->{'workgroup_id'}{'value'};
 
+    my $vrf_id = $params->{'vrf_id'}{'value'};
+    my $circuit_id = $params->{'circuit_id'}{'value'};
+
     my $interface = OESS::Interface->new(interface_id => $interface_id, db => $db);
     if(!defined($interface)){
         $method->set_error("Unable to build interface $interface_id: " . $db->get_error);
         return;
     }
 
+    my $already_used_vlan;
+    if(defined($vrf_id)){
+        my $vrf = OESS::VRF->new( vrf_id => $vrf_id, db => $db);
+        if(!defined($vrf)){
+            $method->set_error("unable to find VRF: $vrf_id");
+            return;
+        }
+        
+        foreach my $ep (@{$vrf->endpoints()}){
+            if($ep->interface()->interface_id() == $interface_id){
+                $already_used_vlan = $ep->tag();
+            }
+        }
+    }
+    
+
     my @allowed_vlans;
     for(my $i=1;$i<=4095;$i++){
+        if(defined($already_used_vlan) && $already_used_vlan == $i){
+            push(@allowed_vlans,$i);
+            next;
+        }
         if($interface->vlan_valid( workgroup_id => $workgroup_id, vlan => $i )){
             push(@allowed_vlans,$i);
         }
+        
     }
 
     return {results => {available_vlans => \@allowed_vlans}};

--- a/frontend/www/js_templates/api/interfaces.js
+++ b/frontend/www/js_templates/api/interfaces.js
@@ -47,12 +47,21 @@ async function getInterfacesByWorkgroup(workgroupID, trunk=1) {
 /**
  *
  */
-async function getEntities(workgroupID, parentEntityID=null) {
+async function getEntities(workgroupID, parentEntityID=null, options) {
   let url = `[% path %]services/entity.cgi?method=get_entity&workgroup_id=${workgroupID}&entity_id=1`;
   if (parentEntityID !== null) {
       url = `[% path %]services/entity.cgi?method=get_entity&workgroup_id=${workgroupID}&entity_id=${parentEntityID}`;
   }
-
+  if(options !== undefined){
+      if(options.vrf != null){
+          url += "&vrf_id=" + options.vrf.vrf_id;
+      }
+      
+      if(options.circuit_id != null){
+          url += "&circuit_id=" + options.circuit.circuit_id;
+      }
+      
+  }
   try {
     const resp = await fetch(url, {method: 'get', credentials: 'include'});
     const data = await resp.json();

--- a/frontend/www/js_templates/api/interfaces.js
+++ b/frontend/www/js_templates/api/interfaces.js
@@ -31,7 +31,7 @@ async function getInterfaces(workgroupID, nodeName, trunk=1) {
  * @param {integer} [trunk=1] - Include trunk interfaces
  */
 async function getInterfacesByWorkgroup(workgroupID, trunk=1) {
-  let url = `[% path %]services/data.cgi?method=get_workgroup_interfaces&workgroup_id=${workgroupID}&show_down=1&show_trunk=${trunk}`;
+    let url = `[% path %]services/interface.cgi?method=get_workgroup_interfaces&workgroup_id=${workgroupID}`;
 
   try {
     const resp = await fetch(url, {method: 'get', credentials: 'include'});

--- a/frontend/www/js_templates/api/vlan.js
+++ b/frontend/www/js_templates/api/vlan.js
@@ -5,8 +5,16 @@
  * @param {integer} workgroupID - Identifier of the current workgroup
  * @param {integer} interfaceID - Identifier of the relevant interface
  */
-async function getAvailableVLANs(workgroupID, interfaceID) {
+async function getAvailableVLANs(workgroupID, interfaceID, vrfID, circuitID) {
     let url = `[% path %]services/interface.cgi?method=get_available_vlans&interface_id=${interfaceID}&workgroup_id=${workgroupID}`;
+
+    if(! vrfID == undefined){
+        url += "&vrf_id=" + vrfId;
+    }
+
+    if(! circuitID == undefined){
+        url += "&circuit_id=" + circuitId;
+    }
 
     try {
         const resp = await fetch(url, {method: 'get', credentials: 'include'});

--- a/frontend/www/js_templates/modify_cloud.js
+++ b/frontend/www/js_templates/modify_cloud.js
@@ -36,7 +36,8 @@ async function loadVRF() {
   vrf.endpoints.forEach(function(e) {
     let endpoint = {
         bandwidth: e.bandwidth,
-        entity_id: -1,
+        entity_id: e.entity.entity_id,
+        entity: e.entity.name,
         name: e.interface.name,
         node: e.node.name,
         peerings: [],
@@ -58,6 +59,7 @@ async function loadVRF() {
   });
 
   sessionStorage.setItem('endpoints', JSON.stringify(endpoints));
+  sessionStorage.setItem('vrf',JSON.stringify(vrf));
   loadSelectedEndpointList();
 }
 
@@ -69,7 +71,7 @@ async function modifyNetworkEndpointCallback(index) {
     let endpoints = JSON.parse(sessionStorage.getItem('endpoints'));
     endpoints[index].index = index;
 
-    showEndpointSelectionModal(endpoints[index]);
+    showEndpointSelectionModal(endpoints[index], {vrf: JSON.parse(sessionStorage.getItem('vrf'))});
 }
 
 async function deleteNetworkEndpointCallback(index) {
@@ -142,7 +144,10 @@ async function addEntitySubmitCallback(event) {
     let entity = {
         bandwidth: document.querySelector('#entity-bandwidth').value,
         entity_id: document.querySelector('#entity-id').value,
-        name: document.querySelector('#entity-name').value,
+        entity: document.querySelector('#entity-name').value,
+        node: "TBD",
+        name: "TBD",
+        //name: document.querySelector('#entity-name').value,
         peerings: [],
         tag: document.querySelector('#entity-vlans').value
     };
@@ -302,11 +307,7 @@ function loadSelectedEndpointList() {
   console.log(endpoints);
   endpoints.forEach(function(endpoint, index) {
           let endpointName = '';
-          if ('entity_id' in endpoint) {
-              endpointName = `${endpoint.name} <small>${endpoint.tag}</small>`;
-          } else {
-              endpointName = `${endpoint.node} <small>${endpoint.interface} - ${endpoint.tag}</small>`;
-          }
+          endpointName = `${endpoint.entity} - ${endpoint.node} - ${endpoint.name} <small>${endpoint.tag}</small>`;
 
           let peerings = '';
           endpoint.peerings.forEach(function(peering, peeringIndex) {

--- a/frontend/www/js_templates/modify_cloud.js
+++ b/frontend/www/js_templates/modify_cloud.js
@@ -308,7 +308,7 @@ function loadSelectedEndpointList() {
   endpoints.forEach(function(endpoint, index) {
           let endpointName = '';
           endpointName = `${endpoint.entity} - ${endpoint.node} - ${endpoint.name} <small>${endpoint.tag}</small>`;
-
+         
           let peerings = '';
           endpoint.peerings.forEach(function(peering, peeringIndex) {
                   peerings += `

--- a/frontend/www/js_templates/provision_cloud.js
+++ b/frontend/www/js_templates/provision_cloud.js
@@ -184,13 +184,9 @@ function loadSelectedEndpointList() {
   endpoints.forEach(function(endpoint, index) {
           let endpointName = '';
           if ('entity_id' in endpoint) {
-              if (endpoint.interface === '') {
-                  endpointName = `${endpoint.entity} <small>${endpoint.tag}</small>`;
-              } else {
-                  endpointName = `${endpoint.entity} <small>${endpoint.interface} ${endpoint.tag}</small>`;
-              }
+              endpointName = `${endpoint.entity} ${endpoint.node} <small>${endpoint.name} ${endpoint.tag}</small>`;
           } else {
-              endpointName = `${endpoint.node} <small>${endpoint.interface} - ${endpoint.tag}</small>`;
+              endpointName = `${endpoint.node} <small>${endpoint.name} - ${endpoint.tag}</small>`;
           }
 
           let peerings = '';

--- a/frontend/www/js_templates/provision_cloud.js
+++ b/frontend/www/js_templates/provision_cloud.js
@@ -185,9 +185,9 @@ function loadSelectedEndpointList() {
           let endpointName = '';
           if ('entity_id' in endpoint) {
               if (endpoint.interface === '') {
-                  endpointName = `${endpoint.name} <small>${endpoint.tag}</small>`;
+                  endpointName = `${endpoint.entity} <small>${endpoint.tag}</small>`;
               } else {
-                  endpointName = `${endpoint.name} <small>${endpoint.interface} ${endpoint.tag}</small>`;
+                  endpointName = `${endpoint.entity} <small>${endpoint.interface} ${endpoint.tag}</small>`;
               }
           } else {
               endpointName = `${endpoint.node} <small>${endpoint.interface} - ${endpoint.tag}</small>`;

--- a/frontend/www/js_templates/provision_cloud/EndpointSelectionModal.js
+++ b/frontend/www/js_templates/provision_cloud/EndpointSelectionModal.js
@@ -64,12 +64,8 @@ async function showEndpointSelectionModal(endpoint, options) {
         document.querySelector('#endpoint-cloud-account-id').value = endpoint.cloud_account_id;
 
         let addEntitySubmitButton = document.querySelector('#add-entity-submit');
-        if ('entity_id' in endpoint) {
-            addEntitySubmitButton.innerHTML = `Modify ${endpoint.name}`;
-        }
-        if ('entity_id' in endpoint && endpoint.interface !== '') {
-            addEntitySubmitButton.innerHTML = `Modify ${endpoint.name} on ${endpoint.interface}`;
-        }
+        addEntitySubmitButton.innerHTML = `Modify Endpoint`;
+
 
     } else {
         document.querySelector('#endpoint-select-header').innerHTML = 'Add Network Endpoint';
@@ -297,8 +293,8 @@ async function loadInterfaces() {
 
     let options = '';
     interfaces.forEach(function(intf) {
-            options += `<option data-id="${intf.interface_id}" data-cloud-interconnect-id="${intf.cloud_interconnect_id}" data-cloud-interconnect-type="${intf.cloud_interconnect_type}" data-node="${intf.node_name}" data-interface="${intf.interface_name}" value="${intf.node_name} - ${intf.interface_name}">
-                          ${intf.node_name} - ${intf.interface_name}
+            options += `<option data-entity="${intf.entity}" data-entity="${intf.entity_id}" data-id="${intf.interface_id}" data-cloud-interconnect-id="${intf.cloud_interconnect_id}" data-cloud-interconnect-type="${intf.cloud_interconnect_type}" data-node="${intf.node}" data-interface="${intf.name}" value="${intf.name} - ${intf.name}">
+                          ${intf.node} - ${intf.name}
                         </option>`;
     });
     document.querySelector('#endpoint-select-interface').innerHTML = options;
@@ -341,11 +337,17 @@ async function addInterfaceSubmitCallback(event) {
     let select = document.querySelector('#endpoint-select-interface');
     let node = select.options[select.selectedIndex].getAttribute('data-node');
     let intf = select.options[select.selectedIndex].getAttribute('data-interface');
-
+    let entity = select.options[select.selectedIndex].getAttribute('data-entity');
+    let entity_id = select.options[select.selectedIndex].getAttribute('data-entity_id');
+    if(entity == "undefined" || entity == "" || entity == null || entity == undefined){
+        entity = "NA";
+    }
     let endpoint = {
         bandwidth: document.querySelector('#endpoint-bandwidth').value,
-        interface: intf,
+        name: intf,
         node: node,
+        entity: entity,
+        entity_id: entity_id,
         peerings: [],
         cloud_account_id: document.querySelector('#endpoint-cloud-account-id').value,
         tag: document.querySelector('#endpoint-vlans').value

--- a/frontend/www/js_templates/provision_cloud/EndpointSelectionModal.js
+++ b/frontend/www/js_templates/provision_cloud/EndpointSelectionModal.js
@@ -16,14 +16,14 @@ document.addEventListener('DOMContentLoaded', function() {
   endpointInterfaceSelect.addEventListener('change', loadInterfaceCloudAccountInput);
 });
 
-async function showEndpointSelectionModal(endpoint) {
+async function showEndpointSelectionModal(endpoint, options) {
     if (endpoint) {
         document.querySelector('#endpoint-select-header').innerHTML = 'Modify Network Endpoint';
 
         if ('entity_id' in endpoint && endpoint.entity_id !== -1) {
             $('#basic').tab('show');
 
-            await loadEntities(endpoint.entity_id);
+            await loadEntities(endpoint.entity_id, options);
             await loadInterfaces();
 
             document.querySelector('#entity-index').value = endpoint.index;
@@ -107,8 +107,8 @@ async function hideEndpointSelectionModal(index) {
     endpointSelectionModal.modal('hide');
 }
 
-async function loadEntities(parentEntity=null) {
-    let entity = await getEntities(session.data.workgroup_id, parentEntity);
+async function loadEntities(parentEntity=null, options) {
+    let entity = await getEntities(session.data.workgroup_id, parentEntity, options);
 
     let parent = null;
     if ('parents' in entity && entity.parents.length > 0) {
@@ -222,14 +222,16 @@ async function addEntitySubmitCallback(event) {
 
     let entity = {
         bandwidth: document.querySelector('#entity-bandwidth').value,
-        interface: document.querySelector('#entity-interface').value,
-        node: document.querySelector('#entity-node').value,
+        interface: "TBD",
+        node: "TBD",
+        name: "TBD",
         peerings: [],
         tag: document.querySelector('#entity-vlans').value,
         entity_id: document.querySelector('#entity-id').value,
-        name: document.querySelector('#entity-name').value,
+        entity: document.querySelector('#entity-name').value,
         cloud_account_id: document.querySelector('#entity-cloud-account-id').value
     };
+
     console.log(entity);
 
     let endpoints = JSON.parse(sessionStorage.getItem('endpoints'));

--- a/frontend/www/js_templates/welcome.js
+++ b/frontend/www/js_templates/welcome.js
@@ -72,8 +72,8 @@ async function loadEntityList() {
             owner = 0;
         }
 
-        let edit = "<a href='?action=modify_cloud&vrf_id=${entity.vrf_id}'><span class='glyphicon glyphicon-edit' style='padding-right: 9px;'></span></a>";
-        let del = "<a onclick='deleteConnection(${entity.vrf_id}, '${entity.name}')' href='javascript:void(0)'><span class='glyphicon glyphicon-trash' style='padding-right: 9px;'></span></a>";
+        let edit = `<a href='?action=modify_cloud&vrf_id=${entity.vrf_id}'><span class='glyphicon glyphicon-edit' style='padding-right: 9px;'></span></a>`;
+        let del = `<a onclick='deleteConnection(${entity.vrf_id}, '${entity.name}')' href='javascript:void(0)'><span class='glyphicon glyphicon-trash' style='padding-right: 9px;'></span></a>`;
         if(owner != 1){
             edit = "<span class='glyphicon glyphicon-edit' style='padding-right: 9px;'></span>";
             del = "<span class='glyphicon glyphicon-trash' style='padding-right: 9px;'></span>";

--- a/perl-lib/OESS/lib/OESS/ACL.pm
+++ b/perl-lib/OESS/lib/OESS/ACL.pm
@@ -43,6 +43,7 @@ sub from_hash{
     foreach my $acl (@$hash){
 
         push(@acls, { workgroup_id => $acl->{'workgroup_id'},
+                      entity_id => $acl->{'entity_id'},
                       allow_deny => $acl->{'allow_deny'},
                       eval_position => $acl->{'eval_position'},
                       start => $acl->{'vlan_start'},
@@ -77,6 +78,11 @@ sub _fetch_from_db{
     my $acls = OESS::DB::Interface::get_acls( db => $self->{'db'}, interface_id => $self->{'interface_id'} );
     $self->from_hash($acls);
 
+}
+
+sub acls{
+    my $self = shift;
+    return $self->{'acls'};
 }
 
 sub vlan_allowed{

--- a/perl-lib/OESS/lib/OESS/DB/Entity.pm
+++ b/perl-lib/OESS/lib/OESS/DB/Entity.pm
@@ -17,12 +17,17 @@ sub fetch{
 
     my $entity_id = $params{'entity_id'};
     my $entity_name = $params{'name'};
+    my $interface_id = $params{'interface_id'};
 
     my $entity;
     if(defined($entity_id)){
         $entity = $db->execute_query("select * from entity where entity_id = ?",[$entity_id]);
-    }else{
+    }elsif(defined($entity_name)){
         $entity = $db->execute_query("select * from entity where name = ?",[$entity_name]);
+    }elsif(defined($interface_id)){
+        $entity = $db->execute_query("select * from entity where entity_id in (select entity_id from entity_interface_membership where interface_id = ?)",[$interface_id]);
+    }else{
+        return;
     }
 
     return if (!defined($entity) || !defined($entity->[0]));

--- a/perl-lib/OESS/lib/OESS/DB/Workgroup.pm
+++ b/perl-lib/OESS/lib/OESS/DB/Workgroup.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use OESS::User;
+use OESS::Interface;
 
 package OESS::DB::Workgroup;
 
@@ -11,34 +12,38 @@ sub fetch{
     my %params = @_;
     my $db = $params{'db'};
     my $workgroup_id = $params{'workgroup_id'};
-
+    
     my $wg = $db->execute_query("select * from workgroup where workgroup_id = ?",[$workgroup_id]);
     if(!defined($wg) || !defined($wg->[0])){
         return;
     }
-
+    
+    my @ints;
+    my $interfaces = $db->execute_query("select interface_id from interface where workgroup_id = ?",[$workgroup_id]);
+    $wg->[0]->{'interfaces'} = $interfaces;
+    
     return $wg->[0];
 }
 
 sub get_users_in_workgroup{
     my %params = @_;
-
+    
     my $db = $params{'db'};
     my $workgroup_id = $params{'workgroup_id'};
-
+    
     my $users = $db->execute_query("select user_id from user_workgroup_membership where workgroup_id = ?",[$workgroup_id]);
     if(!defined($users)){
         return;
     }
-
+    
     my @users;
-
+    
     foreach my $u (@$users){
         my $user = OESS::User->new(db => $db, user_id => $u->{'user_id'});
         if(!defined($user)){
             next;
         }
-
+        
         push(@users, $user);
     }
     return \@users;

--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -31,11 +31,11 @@ OESS::Database - Database Interaction Module
 
 =head1 VERSION
 
-Version 1.2.5
+Version 2.0.0
 
 =cut
 
-our $VERSION = '1.2.5';
+our $VERSION = '2.0.0';
 
 =head1 SYNOPSIS
 
@@ -83,7 +83,7 @@ use Data::Dumper;
 
 use Socket qw( inet_aton inet_ntoa);
 
-use constant VERSION => '1.2.5';
+use constant VERSION => '2.0.0';
 use constant MAX_VLAN_TAG => 4096;
 use constant MIN_VLAN_TAG => 1;
 use constant OESS_PW_FILE => "/etc/oess/.passwd.xml";

--- a/perl-lib/OESS/lib/OESS/Entity.pm
+++ b/perl-lib/OESS/lib/OESS/Entity.pm
@@ -52,7 +52,7 @@ sub _from_hash{
 sub _fetch_from_db{
     my $self = shift;
 
-    my $info = OESS::DB::Entity::fetch(db => $self->{'db'}, entity_id => $self->{'entity_id'}, name => $self->{'name'});
+    my $info = OESS::DB::Entity::fetch(db => $self->{'db'}, entity_id => $self->{'entity_id'}, name => $self->{'name'}, interface_id => $self->{'interface_id'});
     return 0 if !defined($info);
 
     $self->_from_hash($info);

--- a/perl-lib/OESS/lib/OESS/Interface.pm
+++ b/perl-lib/OESS/lib/OESS/Interface.pm
@@ -219,6 +219,7 @@ sub mpls_range{
     return $self->{'mpls_range'};
 }
 
+
 sub vlan_valid{
     my $self = shift;
     my %params = @_;

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -380,7 +380,7 @@ sub get_system_information{
 
     $self->{'loopback_addr'} = $loopback_addr;
     $self->{'major_rev'} = $major_rev;
-    return {model => $model, version => $version, os_name => $os_name, host_name => $host_name, loopback_addr => $loopback_addr, major_rev => $major_rev};
+    return {model => $model, version => $version, os_name => $os_name, host_name => $host_name, loopback_addr => $loopback_addr};
 }
 
 =head2 get_routed_lsps

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -642,7 +642,7 @@ sub get_vrf_stats{
     my %vrf_stats;
 
     my $stats = $self->{'jnx'}->get_dom();
-    #$self->{'logger'}->debug("VRF Stats: " . $stats->toString());
+    $self->{'logger'}->debug("VRF Stats: " . $stats->toString());
     
     my @peer_stats;
     my @rib_stats;

--- a/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
@@ -551,7 +551,7 @@ sub handle_vrf_stats{
 
     my $time = time();
     my $tsds_val = ();
-
+    $self->{'logger'}->debug("Handling RIB stats: " . Dumper($rib_stats));
     while (scalar(@$rib_stats) > 0){
         my $rib = shift @$rib_stats;
         my $meta = { routing_table => $rib->{'vrf'},
@@ -566,10 +566,12 @@ sub handle_vrf_stats{
                            meta => $meta});
 
         if(scalar(@$tsds_val) >= MAX_TSDS_MESSAGES || scalar(@$rib_stats) == 0){
-            $self->{'tsds_svc'}->add_data(data => encode_json($tsds_val));
+            $self->{'logger'}->debug(Dumper($self->{'tsds_svc'}->add_data(data => encode_json($tsds_val))));
             $tsds_val = ();
         }
     }
+
+    $self->{'logger'}->debug("Handling Peer stats: " . Dumper($peer_stats));
 
     while (scalar(@$peer_stats) > 0){
         my $peer = shift @$peer_stats;
@@ -606,7 +608,8 @@ sub handle_vrf_stats{
                            meta => $meta});
 
         if(scalar(@$tsds_val) >= MAX_TSDS_MESSAGES || scalar(@$peer_stats) == 0){
-            $self->{'tsds_svc'}->add_data(data => encode_json($tsds_val));
+            $self->{'logger'}->debug("Sending: " . Dumper($tsds_val));
+            $self->{'logger'}->debug(Dumper("Response: " . Dumper($self->{'tsds_svc'}->add_data(data => encode_json($tsds_val)))));
             $tsds_val = ();
         }
     }    

--- a/perl-lib/OESS/lib/OESS/Workgroup.pm
+++ b/perl-lib/OESS/lib/OESS/Workgroup.pm
@@ -6,7 +6,7 @@ use warnings;
 package OESS::Workgroup;
 
 use OESS::DB::Workgroup;
-
+use Data::Dumper;
 sub new{
     my $that  = shift;
     my $class = ref($that) || $that;
@@ -47,6 +47,12 @@ sub from_hash{
     $self->{'type'} = $hash->{'type'};
     $self->{'max_circuits'} = $hash->{'max_circuits'};
     $self->{'external_id'} = $hash->{'external_id'};
+    $self->{'interfaces'} = ();
+
+    foreach my $int (@{$hash->{'interfaces'}}){
+        push(@{$self->{'interfaces'}}, OESS::Interface->new(interface_id => $int->{'interface_id'}, db => $self->{'db'}));
+    }
+
 }
 
 sub to_hash{
@@ -61,11 +67,17 @@ sub to_hash{
     #$obj->{'users'} = ();
     $obj->{'external_id'} = $self->external_id();
     $obj->{'max_circuits'} = $self->max_circuits();    
-    
+    $obj->{'interfaces'} = ();;
+
     foreach my $user (@{$self->users()}){
         push(@{$self->{'users'}}, $user->to_hash());
     }
-    
+   
+    foreach my $int (@{$self->interfaces()}){
+        warn Dumper($int);
+        push(@{$obj->{'interfaces'}}, $int->to_hash());
+    }
+ 
     return $obj;
 }
 
@@ -109,6 +121,11 @@ sub name{
 sub users{
     my $self = shift;
     return $self->{'users'} || [];
+}
+
+sub interfaces{
+    my $self = shift;
+    return $self->{'interfaces'} || [];
 }
 
 sub type{

--- a/perl-lib/OESS/share/nddi.sql
+++ b/perl-lib/OESS/share/nddi.sql
@@ -147,6 +147,41 @@ LOCK TABLES `circuit_instantiation` WRITE;
 /*!40000 ALTER TABLE `circuit_instantiation` ENABLE KEYS */;
 UNLOCK TABLES;
 
+
+--
+-- Table structure for table `cloud_connection_vrf_ep`
+--
+
+DROP TABLE IF EXISTS `cloud_connection_vrf_ep`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `cloud_connection_vrf_ep` (
+  `cloud_connection_vrf_ep_id` int(11) NOT NULL AUTO_INCREMENT,
+  `vrf_ep_id` int(11) DEFAULT NULL,
+  `cloud_account_id` varchar(255) NOT NULL,
+  `cloud_connection_id` varchar(255) NOT NULL,
+  PRIMARY KEY (`cloud_connection_vrf_ep_id`),
+  KEY `vrf_ep_id` (`vrf_ep_id`),
+  CONSTRAINT `cloud_connection_vrf_ep_ibfk_1` FOREIGN KEY (`vrf_ep_id`) REFERENCES `vrf_ep` (`vrf_ep_id`) ON DELETE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=38 DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `command`
+--
+
+DROP TABLE IF EXISTS `command`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `command` (
+  `command_id` int(10) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `template` varchar(255) NOT NULL,
+  `type` varchar(255) NOT NULL,
+  PRIMARY KEY (`command_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
 --
 -- Table structure for table `edge_interface_move_maintenance`
 --
@@ -177,6 +212,54 @@ LOCK TABLES `edge_interface_move_maintenance` WRITE;
 /*!40000 ALTER TABLE `edge_interface_move_maintenance` DISABLE KEYS */;
 /*!40000 ALTER TABLE `edge_interface_move_maintenance` ENABLE KEYS */;
 UNLOCK TABLES;
+
+--
+-- Table structure for table `entity`
+--
+
+DROP TABLE IF EXISTS `entity`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `entity` (
+  `entity_id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) DEFAULT NULL,
+  `description` text,
+  `logo_url` varchar(255) DEFAULT NULL,
+  `url` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`entity_id`)
+) ENGINE=MyISAM AUTO_INCREMENT=15 DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `entity_hierarchy`
+--
+
+DROP TABLE IF EXISTS `entity_hierarchy`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `entity_hierarchy` (
+  `entity_parent_id` int(11) NOT NULL,
+  `entity_child_id` int(11) NOT NULL,
+  KEY `entity_parent` (`entity_parent_id`),
+  KEY `entity_child` (`entity_child_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `entity_interface_membership`
+--
+
+DROP TABLE IF EXISTS `entity_interface_membership`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `entity_interface_membership` (
+  `entity_id` int(11) NOT NULL,
+  `interface_id` int(11) NOT NULL,
+  UNIQUE KEY `unique_entity_interface` (`entity_id`,`interface_id`),
+  KEY `interface` (`interface_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
 
 --
 -- Table structure for table `edge_interface_move_maintenance_circuit_membership`
@@ -830,6 +913,21 @@ INSERT INTO `user` VALUES (1,'system@localhost','system','system',0,'normal','ac
 UNLOCK TABLES;
 
 --
+-- Table structure for table `user_entity_membership`
+--
+
+DROP TABLE IF EXISTS `user_entity_membership`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `user_entity_membership` (
+  `user_id` int(11) NOT NULL,
+  `entity_id` int(11) NOT NULL,
+  KEY `entity` (`entity_id`),
+  KEY `user` (`user_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `user_workgroup_membership`
 --
 
@@ -924,23 +1022,6 @@ LOCK TABLES `vrf_ep` WRITE;
 /*!40000 ALTER TABLE `vrf_ep` ENABLE KEYS */;
 UNLOCK TABLES;
 
-DROP TABLE IF EXISTS `cloud_connection_vrf_ep`;
-CREATE TABLE `cloud_connection_vrf_ep` (
-  `cloud_connection_vrf_ep_id` int(11) NOT NULL AUTO_INCREMENT,
-  `vrf_ep_id` int(11) DEFAULT NULL,
-  `cloud_account_id` varchar(255) NOT NULL,
-  `cloud_connection_id` varchar(255) NOT NULL,
-  PRIMARY KEY (`cloud_connection_vrf_ep_id`),
-  KEY `vrf_ep_id` (`vrf_ep_id`),
-  CONSTRAINT `cloud_connection_vrf_ep_ibfk_1` FOREIGN KEY (`vrf_ep_id`) REFERENCES `vrf_ep` (`vrf_ep_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-
-LOCK TABLES `cloud_connection_vrf_ep` WRITE;
-/*!40000 ALTER TABLE `cloud_connection_vrf_ep` DISABLE KEYS */;
-/*!40000 ALTER TABLE `cloud_connection_vrf_ep` ENABLE KEYS */;
-UNLOCK TABLES;
-
 --
 -- Table structure for table `vrf_ep_peer`
 --
@@ -1020,88 +1101,6 @@ CREATE TABLE `workgroup_node_membership` (
 --
 -- Table structure for table `workgroup_node_membership`
 --
-
-DROP TABLE IF EXISTS `entity`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-
-CREATE TABLE `entity` (
-  `entity_id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) DEFAULT NULL,
-  `description` text,
-  `logo_url` varchar(255) DEFAULT NULL,
-  `url` varchar(255) DEFAULT NULL,
-  PRIMARY KEY (`entity_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `entity`
---
-
-LOCK TABLES `entity` WRITE;
-/*!40000 ALTER TABLE `entity` DISABLE KEYS */;
-INSERT INTO `entity` VALUES (1,'root');
-/*!40000 ALTER TABLE `entity` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `entity_hierarchy`
---
-
-DROP TABLE IF EXISTS `entity_hierarchy`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-
-CREATE TABLE `entity_hierarchy` (
-  `entity_parent_id` int(11) NOT NULL,
-  `entity_child_id` int(11) NOT NULL,
-  KEY `entity_parent` (`entity_parent_id`),
-  KEY `entity_child` (`entity_child_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Table structure for table `entity_hierarchy`
---                                                                                                                                                                                                                 
-
-DROP TABLE IF EXISTS `entity_interface_membership`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-
-CREATE TABLE `entity_interface_membership` (
-  `entity_id` int(11) NOT NULL,
-  `interface_id` int(11) NOT NULL,
-  UNIQUE KEY `unique_entity_interface` (`entity_id`,`interface_id`),
-  KEY `interface` (`interface_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
-
---
--- Table structure for table `command`
---
-
-DROP TABLE IF EXISTS `command`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `command` (
-  `command_id` int(10) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL,
-  `template` varchar(255) NOT NULL,
-  `type` varchar(255) NOT NULL,
-  PRIMARY KEY (`command_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `command`
---
-
-LOCK TABLES `command` WRITE;
-/*!40000 ALTER TABLE `command` DISABLE KEYS */;
-/*!40000 ALTER TABLE `command` ENABLE KEYS */;
-UNLOCK TABLES;
 
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/perl-lib/OESS/share/nddi.sql
+++ b/perl-lib/OESS/share/nddi.sql
@@ -163,7 +163,7 @@ CREATE TABLE `cloud_connection_vrf_ep` (
   PRIMARY KEY (`cloud_connection_vrf_ep_id`),
   KEY `vrf_ep_id` (`vrf_ep_id`),
   CONSTRAINT `cloud_connection_vrf_ep_ibfk_1` FOREIGN KEY (`vrf_ep_id`) REFERENCES `vrf_ep` (`vrf_ep_id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=38 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -342,9 +342,12 @@ CREATE TABLE `interface_acl` (
   `vlan_start` int(10) NOT NULL,
   `vlan_end` int(10) DEFAULT NULL,
   `notes` text,
+  `entity_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`interface_acl_id`),
   KEY `workgroup_id` (`workgroup_id`),
   KEY `interface_id` (`interface_id`),
+  KEY `entity_fk` (`entity_id`),
+  CONSTRAINT `entity_fk` FOREIGN KEY (`entity_id`) REFERENCES `entity` (`entity_id`),
   CONSTRAINT `interface_acl_ibfk_1` FOREIGN KEY (`interface_id`) REFERENCES `interface` (`interface_id`),
   CONSTRAINT `interface_acl_ibfk_2` FOREIGN KEY (`workgroup_id`) REFERENCES `workgroup` (`workgroup_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/perl-lib/OESS/share/nddi.sql
+++ b/perl-lib/OESS/share/nddi.sql
@@ -78,7 +78,7 @@ CREATE TABLE `circuit_edge_interface_membership` (
   KEY `circuit_circuit_interface_membership_fk` (`circuit_id`),
   CONSTRAINT `circuit_edge_interface_membership_ibfk_1` FOREIGN KEY (`interface_id`) REFERENCES `interface` (`interface_id`),
   CONSTRAINT `circuit_edge_interface_membership_ibfk_2` FOREIGN KEY (`circuit_id`) REFERENCES `circuit` (`circuit_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=81 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -179,7 +179,7 @@ CREATE TABLE `command` (
   `template` varchar(255) NOT NULL,
   `type` varchar(255) NOT NULL,
   PRIMARY KEY (`command_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -227,7 +227,7 @@ CREATE TABLE `entity` (
   `logo_url` varchar(255) DEFAULT NULL,
   `url` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`entity_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=15 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -552,19 +552,8 @@ CREATE TABLE `network` (
   `is_local` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`network_id`),
   UNIQUE KEY `network_idx` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `network`
---
-
-LOCK TABLES `network` WRITE;
-/*!40000 ALTER TABLE `network` DISABLE KEYS */;
-INSERT INTO `network` VALUES (1,'aj-dev7.grnoc.iu.edu',0,0,1);
-/*!40000 ALTER TABLE `network` ENABLE KEYS */;
-UNLOCK TABLES;
-
 --
 -- Table structure for table `node`
 --
@@ -684,7 +673,7 @@ CREATE TABLE `oess_version` (
 
 LOCK TABLES `oess_version` WRITE;
 /*!40000 ALTER TABLE `oess_version` DISABLE KEYS */;
-INSERT INTO `oess_version` VALUES ('1.2.5');
+INSERT INTO `oess_version` VALUES ('2.0.0');
 /*!40000 ALTER TABLE `oess_version` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -733,7 +722,7 @@ CREATE TABLE `path_instantiation` (
   PRIMARY KEY (`path_instantiation_id`),
   KEY `end_epoch_path` (`path_id`,`end_epoch`),
   CONSTRAINT `path_path_instantiaiton_fk` FOREIGN KEY (`path_id`) REFERENCES `path` (`path_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -787,7 +776,7 @@ CREATE TABLE `remote_auth` (
   UNIQUE KEY `remote_auth_idx` (`auth_name`),
   KEY `user_auth_values_fk` (`user_id`),
   CONSTRAINT `user_auth_values_fk` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -796,7 +785,6 @@ CREATE TABLE `remote_auth` (
 
 LOCK TABLES `remote_auth` WRITE;
 /*!40000 ALTER TABLE `remote_auth` DISABLE KEYS */;
-INSERT INTO `remote_auth` VALUES (1,'aragusa',2);
 /*!40000 ALTER TABLE `remote_auth` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -902,18 +890,8 @@ CREATE TABLE `user` (
   `status` enum('active','decom') NOT NULL DEFAULT 'active',
   PRIMARY KEY (`user_id`),
   KEY `user_idx` (`email`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `user`
---
-
-LOCK TABLES `user` WRITE;
-/*!40000 ALTER TABLE `user` DISABLE KEYS */;
-INSERT INTO `user` VALUES (1,'system@localhost','system','system',0,'normal','active'),(2,'aragusa@globalnoc.iu.edu','Andrew','Ragusa',0,'normal','active');
-/*!40000 ALTER TABLE `user` ENABLE KEYS */;
-UNLOCK TABLES;
 
 --
 -- Table structure for table `user_entity_membership`
@@ -946,16 +924,6 @@ CREATE TABLE `user_workgroup_membership` (
   CONSTRAINT `workgroups_user_workgroup_membership_fk` FOREIGN KEY (`workgroup_id`) REFERENCES `workgroup` (`workgroup_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `user_workgroup_membership`
---
-
-LOCK TABLES `user_workgroup_membership` WRITE;
-/*!40000 ALTER TABLE `user_workgroup_membership` DISABLE KEYS */;
-INSERT INTO `user_workgroup_membership` VALUES (1,2);
-/*!40000 ALTER TABLE `user_workgroup_membership` ENABLE KEYS */;
-UNLOCK TABLES;
 
 --
 -- Table structure for table `vrf`
@@ -1071,7 +1039,7 @@ CREATE TABLE `workgroup` (
   `status` enum('active','decom') NOT NULL DEFAULT 'active',
   PRIMARY KEY (`workgroup_id`),
   UNIQUE KEY `workgroups_idx` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1080,7 +1048,6 @@ CREATE TABLE `workgroup` (
 
 LOCK TABLES `workgroup` WRITE;
 /*!40000 ALTER TABLE `workgroup` DISABLE KEYS */;
-INSERT INTO `workgroup` VALUES (1,'','admin',NULL,'admin',10,20,10,'active');
 /*!40000 ALTER TABLE `workgroup` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
So the way we were associating entities with interfaces was not going to succeed long or short term, so we modified it so that instead of direct port mappings, we are going to use the ACLs to control the mappings to ports