### PR TITLE
fixing the ability to edit layer2 vlans

### DIFF
--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -714,6 +714,7 @@ sub is_external_vlan_available_on_interface {
     my $inner_vlan_tag = $args{'inner_vlan'};
     my $interface_id = $args{'interface_id'};
     my $circuit_id = $args{'circuit_id'};
+    my $vrf_id = $args{'vrf_id'};
 
     my $type = 'openflow';
 
@@ -6789,9 +6790,6 @@ sub validate_circuit {
             vlan => $vlans->[$i],
             inner_vlan => $inner_vlans->[$i]
         );
-        if (!$res->{status}) {
-            return (0, "VLAN $vlans->[$i] $inner_vlans->[$i] is not available on $nodes->[$i] $interfaces->[$i].");
-        }
 
         if(!defined($type)){
             $type = $res->{'type'};


### PR DESCRIPTION
this check was added erroniously to the code.  This check will always fail during edit unless you change ALL endpoints vlan tags.  This is not what we want, instead it does a bit more checking inside of the edit vlan code to make sure all is good