### PR TITLE
fixing missing units after doing interface migration via admin section

### DIFF
--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -10116,14 +10116,16 @@ sub move_edge_interface_circuits {
                  "  circuit_id, ".
                  "  start_epoch, ".
                  "  end_epoch, ".
-                 "  extern_vlan_id ) ".
-                 "VALUES( ?,?,?,?,? )";
+                 "  extern_vlan_id, ". 
+                 "  unit ) ".
+                 "VALUES( ?,?,?,?,?, ? )";
         $recs = $self->_execute_query($query, [
-            $new_interface_id, 
-            $edge_int_rec->{'circuit_id'},
-            $now,
-            -1,
-            $edge_int_rec->{'extern_vlan_id'},
+                                          $new_interface_id, 
+                                          $edge_int_rec->{'circuit_id'},
+                                          $now,
+                                          -1,
+                                          $edge_int_rec->{'extern_vlan_id'},
+                                          $edge_int_rec->{'unit'}
         ]);
         if(!$recs){
             $self->_rollback() if($do_commit);

--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -714,6 +714,7 @@ sub is_external_vlan_available_on_interface {
     my $inner_vlan_tag = $args{'inner_vlan'};
     my $interface_id = $args{'interface_id'};
     my $circuit_id = $args{'circuit_id'};
+    my $vrf_id = $args{'vrf_id'};
 
     my $type = 'openflow';
 
@@ -6789,9 +6790,6 @@ sub validate_circuit {
             vlan => $vlans->[$i],
             inner_vlan => $inner_vlans->[$i]
         );
-        if (!$res->{status}) {
-            return (0, "VLAN $vlans->[$i] $inner_vlans->[$i] is not available on $nodes->[$i] $interfaces->[$i].");
-        }
 
         if(!defined($type)){
             $type = $res->{'type'};


### PR DESCRIPTION
This should resolve #751 where circuit edge unit name is missing because it was not migrated when doing the interface migration