### PR TITLE
Adding new diff state 'error'

### DIFF
--- a/frontend/webservice/admin/admin.cgi
+++ b/frontend/webservice/admin/admin.cgi
@@ -43,6 +43,9 @@ use constant FWDCTL_SUCCESS     => 1;
 use constant FWDCTL_FAILURE     => 0;
 use constant FWDCTL_UNKNOWN     => 3;
 
+use constant PENDING_DIFF_NONE  => 0;
+use constant PENDING_DIFF       => 1;
+use constant PENDING_DIFF_ERROR => 2;
 
 Log::Log4perl::init('/etc/oess/logging.conf');
 
@@ -870,7 +873,6 @@ sub get_diff_text {
     return { results => [{ text => $result->{results}}] };
 }
 
-
 =head2 set_diff_approval
 
 Approves or denies diffing for a node with pending configuration
@@ -883,7 +885,12 @@ sub set_diff_approval {
     my $approved = $args->{'approved'}{'value'};
     my $node_id  = $args->{'node_id'}{'value'};
 
-    my $res = $db->set_diff_approval($approved, $node_id);
+    if ($approved != 1) {
+        $method->set_error("Diffs may only be approved via the web API.");
+        return;
+    }
+
+    my $res = $db->set_pending_diff(PENDING_DIFF_NONE, $node_id);
     if (!defined $res) {
         $method->set_error($db->get_error());
         return;

--- a/frontend/www/js_templates/admin.js
+++ b/frontend/www/js_templates/admin.js
@@ -153,12 +153,12 @@ function makeConfigPanel(x, y, width, obj) {
     panel.load_diff      = load_diff;
 
     panel.load = function(node_id, name) {
-	this.setHeader('Configuration Details - ' + name);
-	this.setFooter('Approve this pending configuration?');
+	  this.setHeader('Configuration Details - ' + name);
+	  this.setFooter('Approve this pending configuration?');
 
-	this.approve_button.node_id = node_id;
-	this.load_diff(node_id);
-    }
+	  this.approve_button.node_id = node_id;
+	  this.load_diff(node_id);
+    };
 
     panel.hideEvent.subscribe(function() {
         pre.innerHTML = 'Loading diff...';
@@ -174,10 +174,12 @@ function makeConfigTable(div_id) {
         var is_pending = rec.getData("pending_diff");
         var html;
 
-        if (is_pending == "1") {
-            html = '<p style="color:#BA2617">Pending Approval</p>';
+        if (is_pending == "2") {
+            html = '<p style="color:#BA2617">Error</p>';
+        } else if (is_pending == "1") {
+            html = '<p style="color:#BA7717">Pending Approval</p>';
         } else {
-            html = '<p style="color:#32BA17">OK</p>';
+            html = '<p style="color:#59BA17">OK</p>';
         }
         el.innerHTML = html;
     };

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -1790,7 +1790,7 @@ sub diff {
     }
     if ($diff->{value} eq '') {
         $self->{'logger'}->info('No diff required at this time.');
-        return FWDCTL_FAILURE;
+        return FWDCTL_SUCCESS;
     }
 
     if ($self->_large_diff($diff->{value})) {


### PR DESCRIPTION
This new diff state is used if an error occurs while diffing. This allows us to quickly identify nodes which are unable to sync with oess.