### PR TITLE
Add loading indicators for lengthy actions

### DIFF
--- a/frontend/www/html_templates/modify_cloud.html
+++ b/frontend/www/html_templates/modify_cloud.html
@@ -40,7 +40,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content" style="text-align: center;">
         <img src="[% path %]media/loading.gif" width="200px;"/>
-        <p>Give us just a few seconds. We're in the process of provisioning your network now.</p>
+        <p>Give us just a few seconds. We're in the process of provisioning your connection now.</p>
         <br/>
       </div>
     </div>

--- a/frontend/www/html_templates/modify_cloud.html
+++ b/frontend/www/html_templates/modify_cloud.html
@@ -40,7 +40,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content" style="text-align: center;">
         <img src="[% path %]media/loading.gif" width="200px;"/>
-        <p>Give us just a few seconds. We're in process of provisioning your network now.</p>
+        <p>Give us just a few seconds. We're in the process of provisioning your network now.</p>
         <br/>
       </div>
     </div>

--- a/frontend/www/html_templates/modify_l2vpn.html
+++ b/frontend/www/html_templates/modify_l2vpn.html
@@ -65,4 +65,15 @@
   <!-- endpoint modal -->
   <div class="modal fade" role="dialog" tabindex="-1" id="add-endpoint-modal">
   </div>
+
+  <!-- waiting for modification/deletion modal -->
+  <div class="modal fade" role="dialog" tabindex="-1" id="modify-loading">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content" style="text-align: center;">
+        <img src="[% path %]media/loading.gif" width="200px;"/>
+        <p>&nbsp;</p>
+        <br/>
+      </div>
+    </div>
+  </div>
 </div>

--- a/frontend/www/html_templates/provision_cloud.html
+++ b/frontend/www/html_templates/provision_cloud.html
@@ -40,7 +40,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content" style="text-align: center;">
         <img src="[% path %]media/loading.gif" width="200px;"/>
-        <p>Give us just a few seconds. We're in the process of provisioning your network now.</p>
+        <p>Give us just a few seconds. We're in the process of provisioning your connection now.</p>
         <br/>
       </div>
     </div>

--- a/frontend/www/html_templates/provision_cloud.html
+++ b/frontend/www/html_templates/provision_cloud.html
@@ -40,7 +40,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content" style="text-align: center;">
         <img src="[% path %]media/loading.gif" width="200px;"/>
-        <p>Give us just a few seconds. We're in process of provisioning your network now.</p>
+        <p>Give us just a few seconds. We're in the process of provisioning your network now.</p>
         <br/>
       </div>
     </div>

--- a/frontend/www/html_templates/provision_l2vpn.html
+++ b/frontend/www/html_templates/provision_l2vpn.html
@@ -95,7 +95,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content" style="text-align: center;">
         <img src="[% path %]media/loading.gif" width="200px;"/>
-        <p>Give us just a few seconds. We're provisioning your L2VPN now.</p>
+        <p>Give us just a few seconds. We're provisioning your connection now.</p>
         <br/>
       </div>
     </div>

--- a/frontend/www/html_templates/provision_l2vpn.html
+++ b/frontend/www/html_templates/provision_l2vpn.html
@@ -89,4 +89,16 @@
       [% INCLUDE js_templates/provision_l2vpn.js %]
     </script>
 
+
+  <!-- waiting for provision modal -->
+  <div class="modal fade" role="dialog" tabindex="-1" id="add-l2vpn-loading">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content" style="text-align: center;">
+        <img src="[% path %]media/loading.gif" width="200px;"/>
+        <p>Give us just a few seconds. We're provisioning your L2VPN now.</p>
+        <br/>
+      </div>
+    </div>
+  </div>
+
 </div>

--- a/frontend/www/html_templates/view_l3vpn.html
+++ b/frontend/www/html_templates/view_l3vpn.html
@@ -18,6 +18,7 @@
       <div class="modal-content" style="text-align: center;">
         <img src="[% path %]media/loading.gif" width="200px;" />
         <p>Give us a few seconds. We're deleting your L3VPN now.</p>
+        <br />
       </div>
     </div>
   </div>

--- a/frontend/www/html_templates/view_l3vpn.html
+++ b/frontend/www/html_templates/view_l3vpn.html
@@ -17,7 +17,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content" style="text-align: center;">
         <img src="[% path %]media/loading.gif" width="200px;" />
-        <p>Give us a few seconds. We're deleting your L3VPN now.</p>
+        <p>Give us a few seconds. We're deleting your connection now.</p>
         <br />
       </div>
     </div>

--- a/frontend/www/html_templates/view_l3vpn.html
+++ b/frontend/www/html_templates/view_l3vpn.html
@@ -13,6 +13,15 @@
     [% INCLUDE js_templates/view_l3vpn.js %]
   </script>
 
+  <div class="modal fade" role="dialog" tabindex="-1" id="delete-l3vpn-loading">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content" style="text-align: center;">
+        <img src="[% path %]media/loading.gif" width="200px;" />
+        <p>Give us a few seconds. We're deleting your L3VPN now.</p>
+      </div>
+    </div>
+  </div>
+
   <div class="row" style="margin-bottom: 15px">
     <div class="col-md-6">
       <h2 id="description"></h2>

--- a/frontend/www/html_templates/welcome.html
+++ b/frontend/www/html_templates/welcome.html
@@ -38,7 +38,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content" style="text-align: center;">
         <img src="[% path %]media/loading.gif" width="200px;"/>
-        <p>Give us just a few seconds. We're deleting your circuit now.</p>
+        <p>Give us just a few seconds. We're deleting your connection now.</p>
         <br/>
       </div>
     </div>

--- a/frontend/www/html_templates/welcome.html
+++ b/frontend/www/html_templates/welcome.html
@@ -32,4 +32,15 @@
   <h3>Layer2 VPNs</h3>
   <p>&nbsp;</p>
   <div id="l2vpn-list"></div>
+
+  <!-- waiting for deletion modal -->
+  <div class="modal fade" role="dialog" tabindex="-1" id="delete-circuit-loading">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content" style="text-align: center;">
+        <img src="[% path %]media/loading.gif" width="200px;"/>
+        <p>Give us just a few seconds. We're deleting your circuit now.</p>
+        <br/>
+      </div>
+    </div>
+  </div>
 </div>

--- a/frontend/www/js_templates/api/vrf.js
+++ b/frontend/www/js_templates/api/vrf.js
@@ -114,7 +114,7 @@ async function deleteVRF(workgroupID, vrfID) {
     const resp = await fetch(url, {method: 'get', credentials: 'include'});
     const data = await resp.json();
     console.log(data);
-    return data.results[0];
+    return data.results;
   } catch(error) {
     console.log('Failure occurred in deleteVRF.');
     console.log(error);

--- a/frontend/www/js_templates/modify_l2vpn.js
+++ b/frontend/www/js_templates/modify_l2vpn.js
@@ -50,6 +50,11 @@ class GlobalState extends Component {
 
   saveCircuit() {
     console.log('saveCircuit:', this.circuit);
+
+    let provisionModal = $('#modify-loading');
+    provisionModal.find('p').text("Give us a few seconds. We're modifying your L2VPN now.");
+    provisionModal.modal('show');
+
     provisionCircuit(
       session.data.workgroup_id,
       this.circuit.description,
@@ -62,6 +67,10 @@ class GlobalState extends Component {
       if (result !== null && result.success == 1) {
         window.location.href = `index.cgi?action=modify_l2vpn&circuit_id=${result.circuit_id}`;
       }
+      else {
+        provisionModal.modal('hide');
+        window.alert('There was an error modifying the L2VPN.');
+      }
     });
   }
 
@@ -70,12 +79,20 @@ class GlobalState extends Component {
       return null;
     }
 
+    let provisionModal = $('#modify-loading');
+    provisionModal.find('p').text("Give us a few seconds. We're deleting your L2VPN now.");
+    provisionModal.modal('show');
+
     deleteCircuit(
       session.data.workgroup_id,
       this.circuit.circuit_id
     ).then(function(result) {
       if (result !== null) {
         window.location.href = 'index.cgi';
+      }
+      else {
+        provisionModal.modal('hide');
+        window.alert('There was an error deleting the L2VPN.');
       }
     });
   }

--- a/frontend/www/js_templates/modify_l2vpn.js
+++ b/frontend/www/js_templates/modify_l2vpn.js
@@ -52,7 +52,7 @@ class GlobalState extends Component {
     console.log('saveCircuit:', this.circuit);
 
     let provisionModal = $('#modify-loading');
-    provisionModal.find('p').text("Give us a few seconds. We're modifying your L2VPN now.");
+    provisionModal.find('p').text("Give us a few seconds. We're modifying your connection now.");
     provisionModal.modal('show');
 
     provisionCircuit(
@@ -69,7 +69,7 @@ class GlobalState extends Component {
       }
       else {
         provisionModal.modal('hide');
-        window.alert('There was an error modifying the L2VPN.');
+        window.alert('There was an error modifying the connection.');
       }
     });
   }
@@ -80,7 +80,7 @@ class GlobalState extends Component {
     }
 
     let provisionModal = $('#modify-loading');
-    provisionModal.find('p').text("Give us a few seconds. We're deleting your L2VPN now.");
+    provisionModal.find('p').text("Give us a few seconds. We're deleting your connection now.");
     provisionModal.modal('show');
 
     deleteCircuit(
@@ -92,7 +92,7 @@ class GlobalState extends Component {
       }
       else {
         provisionModal.modal('hide');
-        window.alert('There was an error deleting the L2VPN.');
+        window.alert('There was an error deleting the connection.');
       }
     });
   }

--- a/frontend/www/js_templates/provision_l2vpn.js
+++ b/frontend/www/js_templates/provision_l2vpn.js
@@ -32,6 +32,9 @@ class GlobalState extends Component {
   saveCircuit() {
     console.log('provisionCircuit:', this.circuit);
 
+    let addL2VpnModal = $('#add-l2vpn-loading');
+    addL2VpnModal.modal('show');
+
     provisionCircuit(
       session.data.workgroup_id,
       this.circuit.description,
@@ -43,6 +46,10 @@ class GlobalState extends Component {
     ).then(function(result) {
       if (result !== null && result.success == 1) {
         window.location.href = `index.cgi?action=modify_l2vpn&circuit_id=${result.circuit_id}`;
+      }
+      else {
+        addL2VpnModal.modal('hide');
+        window.alert('There was an error provisioning the L2VPN.');
       }
     });
   }

--- a/frontend/www/js_templates/provision_l2vpn.js
+++ b/frontend/www/js_templates/provision_l2vpn.js
@@ -49,7 +49,7 @@ class GlobalState extends Component {
       }
       else {
         addL2VpnModal.modal('hide');
-        window.alert('There was an error provisioning the L2VPN.');
+        window.alert('There was an error provisioning the connection.');
       }
     });
   }

--- a/frontend/www/js_templates/view_l3vpn.js
+++ b/frontend/www/js_templates/view_l3vpn.js
@@ -84,7 +84,7 @@ async function deleteConnection(id) {
 
         let result = await deleteVRF(session.data.workgroup_id, vrfID);
 
-        if (result !== null) {
+        if (result != null) {
             window.location = '?action=welcome';
         }
         else {

--- a/frontend/www/js_templates/view_l3vpn.js
+++ b/frontend/www/js_templates/view_l3vpn.js
@@ -79,8 +79,18 @@ async function deleteConnection(id) {
 
     let ok = confirm(`Are you sure you want to delete this connection?`);
     if (ok) {
-        await deleteVRF(session.data.workgroup_id, vrfID);
-        window.location = '?action=welcome';
+        let deleteModal = $('#delete-l3vpn-loading');
+        deleteModal.modal('show');
+
+        let result = await deleteVRF(session.data.workgroup_id, vrfID);
+
+        if (result !== null) {
+            window.location = '?action=welcome';
+        }
+        else {
+            deleteModal.modal('hide');
+            alert('There was an error deleting this L3VPN.');
+        }
     }
 }
 

--- a/frontend/www/js_templates/view_l3vpn.js
+++ b/frontend/www/js_templates/view_l3vpn.js
@@ -89,7 +89,7 @@ async function deleteConnection(id) {
         }
         else {
             deleteModal.modal('hide');
-            alert('There was an error deleting this L3VPN.');
+            alert('There was an error deleting this connection.');
         }
     }
 }

--- a/frontend/www/js_templates/welcome.js
+++ b/frontend/www/js_templates/welcome.js
@@ -11,6 +11,9 @@ document.addEventListener('DOMContentLoaded', function() {
 async function deleteConnection(id, name) {
     let ok = confirm(`Are you sure you want to delete ${name}?`);
     if (ok) {
+        let deleteCircuitModal = $('#delete-circuit-loading');
+        deleteCircuitModal.modal('show');
+
         await deleteVRF(session.data.workgroup_id, id);
         window.location = '?action=welcome';
     }
@@ -19,6 +22,9 @@ async function deleteConnection(id, name) {
 async function deleteL2VPN(id, name) {
   let ok = confirm(`Are you sure you want to delete ${name}?`);
   if (ok) {
+    let deleteCircuitModal = $('#delete-circuit-loading');
+    deleteCircuitModal.modal('show');
+
     await deleteCircuit(session.data.workgroup_id, id);
     window.location = '?action=welcome';
   }


### PR DESCRIPTION
This PR contains code to fix issue #851. It has been tested in a dev environment.

One question I have about my changes concerns terminology. We refer to these objects by different names in different places &mdash; e.g., in [html_templates/provision_cloud.html](https://github.com/GlobalNOC/OESS/blob/1e65264c6af82589cf16e4ed5a09eaac49e18fa3/frontend/www/html_templates/provision_cloud.html#L43-L51), the same entity is referred to as both a "network" and an "L3VPN". I wouldn't mind having a check of the language I used in the loading modals to make sure I'm using the right terms for things.