### PR TITLE
Fixing l2 connections requiring site-ids and allowing bad endpoints

### DIFF
--- a/frontend/www/html_templates/l2/endpoint.html
+++ b/frontend/www/html_templates/l2/endpoint.html
@@ -23,7 +23,7 @@
         <h6 class="l2vpn-mtu"></h6>
       </div>
 
-      <iframe class="l2vpn-graph" height="100" frameborder="0" style="flex: 1;"></iframe>
+      <iframe class="l2vpn-graph" height="185" frameborder="0" style="flex: 1;"></iframe>
 
       <div style="display: block;">
         <button class="btn btn-link l2vpn-modify-button" type="button" onclick="" style="padding: 12 6 12 6;">

--- a/frontend/www/js_templates/l2/endpoint.js
+++ b/frontend/www/js_templates/l2/endpoint.js
@@ -10,7 +10,7 @@ function NewEndpoint(endpoint) {
   e.querySelector('.l2vpn-inner-tag').innerHTML = endpoint.inner_tag || null;
   e.querySelector('.l2vpn-bandwidth').innerHTML = (endpoint.bandwidth == null || endpoint.bandwidth == 0) ? 'Unlimited' : `${endpoint.bandwidth} Mb/s`;
   e.querySelector('.l2vpn-mtu').innerHTML = endpoint.mtu;
-  e.querySelector('.l2vpn-graph').setAttribute('src', `https://io3.bldc.grnoc.iu.edu/grafana/d-solo/te5oS11mk/oess-l2-interface?panelId=2&amp;orgId=1&amp;from=now-1h&amp;to=now&amp;var-node=${endpoint.node}&amp;var-interface=${endpoint.interface}&amp;refresh=30s`);
+  e.querySelector('.l2vpn-graph').setAttribute('src', `[% g_l2_port %]&from=now-1h&to=now&var-node=${endpoint.node}&var-interface=${endpoint.interface}.${endpoint.tag}&refresh=30s`);
 
   if (endpoint.inner_tag === undefined || endpoint.inner_tag === null || endpoint.inner_tag === '') {
     Array.from(e.querySelectorAll('.d1q')).map(e => e.style.display = 'block');

--- a/perl-lib/OESS/lib/OESS/L2Circuit.pm
+++ b/perl-lib/OESS/lib/OESS/L2Circuit.pm
@@ -613,7 +613,6 @@ sub get_path{
     my $path = $params{'path'};
 
     if (!defined $path) {
-        $self->{'logger'}->error("Path was not defined.");
         return;
     }
 

--- a/perl-lib/OESS/share/nddi.sql
+++ b/perl-lib/OESS/share/nddi.sql
@@ -663,7 +663,7 @@ CREATE TABLE `oess_version` (
 
 LOCK TABLES `oess_version` WRITE;
 /*!40000 ALTER TABLE `oess_version` DISABLE KEYS */;
-INSERT INTO `oess_version` VALUES ('2.0.3');
+INSERT INTO `oess_version` VALUES ('2.0.4');
 /*!40000 ALTER TABLE `oess_version` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
A change to the way Endpoints are queried from the database resulted
in a new ordering of the Circuit object’s endpoints array. Because of
how l2vpn/l2vpls site-ids are generated, this change in ordering
resulted an expected diff which would have affected a large number of
layer2 circuits.

This same change also had the built in assumption that all existing
Endpoints would respect OESS’s current ACLs, however some Endpoints
are defined using VLANs outside the existing ACL ranges (some are even
defined using interfaces that are not owned by a workgroup). This
resulted in an expected diff that would have removed of Endpoints of
some circuits and changed the circuit type of others.

Both issues were addressed using the same fix. By splitting up the
single query into multiple we are able to maintain the original
endpoint ordering for proper generation of site-ids, and by removing
an INNER JOIN on the interface_acl table we are able to preserve
endpoints existing outside valid OESS ACLs.