### PR TITLE
975 invalid peers

### DIFF
--- a/perl-lib/OESS/lib/OESS/Endpoint.pm
+++ b/perl-lib/OESS/lib/OESS/Endpoint.pm
@@ -65,8 +65,7 @@ B<Example 1:>
         bandwidth           => 100,        # Acts as an interface selector and validator
         workgroup_id        => 10,         # Acts as an interface selector and validator
         mtu                 => 9000,
-        unit                => 345,
-        peerings            => [ {...} ]
+        unit                => 345
     };
     my $endpoint = OESS::Endpoint->new(db => $db, type => 'vrf', model => $json);
 
@@ -82,8 +81,7 @@ B<Example 2:>
         bandwidth           => 100,        # Acts as an interface validator
         workgroup_id        => 10,         # Acts as an interface validator
         mtu                 => 9000,
-        unit                => 345,
-        peerings            => [ {...} ]
+        unit                => 345
     };
     my $endpoint = OESS::Endpoint->new(db => $db, type => 'vrf', model => $json);
 
@@ -167,13 +165,6 @@ sub _build_from_model{
     $self->{circuit_id} = $self->{model}->{circuit_id};
     $self->{vrf_id} = $self->{model}->{vrf_id};
     $self->{start_epoch} = $self->{model}->{start_epoch};
-
-    if ($self->{type} eq 'vrf') {
-        $self->{peers} = [];
-        foreach my $peer (@{$self->{model}->{peers}}) {
-            push @{$self->{peers}}, OESS::Peer->new(db => $self->{'db'}, model => $peer);
-        }
-    }
 }
 
 =head2 to_hash

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -812,12 +812,14 @@ sub remove_vlan{
         {
           interface => 'ge-0/0/1',
           inner_tag => 100,
-          tag => 2004
+          tag => 2004,
+          unit => 2004
         },
         {
           interface => 'ge-0/0/2',
           inner_tag => 100,
-          tag => 2004
+          tag => 2004,
+          unit => 2004
         }
       ],
       paths => [],

--- a/perl-lib/OESS/t/z-Object/Endpoint.t
+++ b/perl-lib/OESS/t/z-Object/Endpoint.t
@@ -1,0 +1,62 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use FindBin;
+my $path;
+
+BEGIN {
+    if ($FindBin::Bin =~ /(.*)/) {
+        $path = $1;
+    }
+}
+use lib "$path/..";
+
+
+use Data::Dumper;
+use Test::More tests => 2;
+
+use OESSDatabaseTester;
+
+use OESS::DB;
+use OESS::Endpoint;
+use OESS::Peer;
+
+OESSDatabaseTester::resetOESSDB(
+    config => "$path/../conf/database.xml",
+    dbdump => "$path/../conf/oess_known_state.sql"
+);
+
+
+my $db = new OESS::DB(
+    config  => "$path/../conf/database.xml"
+);
+
+my $raw = {
+    'bandwidth' => '0',
+    'tag' => '1005',
+    'peers' => [
+        {'asn' => '7','key' => '','local_ip' => '192.168.2.2/24','peer_ip' => '192.168.2.1/24','version' => 4}
+    ],
+    'cloud_account_id' => '',
+    'workgroup_id'   => 1,
+    'entity' => 'Indiana University'
+};
+
+# In some cases an Endpoint may be created with incomplete peering
+# information. In these cases we should auto-generate the missing
+# data; For this reason we do not auto-generate Peer objects inside
+# the Endpoint object constructor. Validate that when creating an
+# Endpoint using a model with pre-defined peers we do not auto-load
+# them into Peer objects.
+
+my $ep = new OESS::Endpoint(db => $db, model => $raw);
+ok(@{$ep->peers} == 0, 'Peers from raw model not auto-parsed into object.');
+
+my $peer_count = @{$raw->{peers}};
+foreach my $raw_peer (@{$raw->{peers}}) {
+    my $peer = new OESS::Peer(db => $db, model => $raw_peer);
+    $ep->add_peer($peer);
+}
+ok(@{$ep->peers} == $peer_count, "$peer_count Peer(s) added to Endpoint from raw model after manual creation.");


### PR DESCRIPTION
In some cases an Endpoint may be created with incomplete peering information. In these cases we should auto-generate the missing data; For this reason we do not auto-generate Peer objects inside the Endpoint object constructor. Validate that when creating an Endpoint using a model with pre-defined peers we do not auto-load them into Peer objects.

Fixes #975 