### PR TITLE
Evpn vxlan

### DIFF
--- a/app/etc/oess-init-rh
+++ b/app/etc/oess-init-rh
@@ -3,7 +3,8 @@
 use strict;
 use warnings;
 
-use OESS::Database;
+use OESS::Config;
+
 use AnyEvent;
 use AnyEvent::DBus;
 use Net::DBus::Annotation qw(:call);
@@ -12,6 +13,8 @@ use constant FWDCTL_WAITING     => 2;
 use constant FWDCTL_SUCCESS     => 1;
 use constant FWDCTL_FAILURE     => 0;
 use constant FWDCTL_UNKNOWN     => 3;
+
+my $config = new OESS::Config;
 
 sub main{
     my $option = shift;
@@ -83,270 +86,229 @@ print $str . "\n";
     }else{
         usage();
     }
-    
 }
 
-sub status{
-    
-    my $db = OESS::Database->new();
+sub status {
     my $result = 0;
 
-    if($db->is_openflow_enabled()){
-	
-	if($db->is_fwdctl_enabled()){
-	    my $res = system("/etc/init.d/oess-fwdctl status");
-	    if($res != 0){
-		$result = $res;
-	    }
-	}
-	
-	
-	if($db->is_vlan_stats_enabled()){
-	    my $res = system("/etc/init.d/oess-vlan_stats status");
-	    if($res != 0){
-		$result = $res;
-	    }
-	}
-	if($db->is_nox_enabled()){
-	    my $res = system("/etc/init.d/nox_cored status");
-	    if($res != 0){
-		$result = $res;
-	    }
-	}
-	
-	if($db->is_fvd_enabled()){
-	    my $res = system("/etc/init.d/oess-fvd status");
-	    if($res != 0){
-		$result = $res;
-	    }
-	}
+    if ($config->openflow_enabled) {
 
-	if($db->is_traceroute_enabled()){
-	    my $res = system("/etc/init.d/oess-traceroute status");
-	    if($res != 0){
-		$result = $res;
-	    }
-	}
+        if ($config->fwdctl_enabled) {
+            my $res = system("/etc/init.d/oess-fwdctl status");
+            if ($res != 0) {
+                $result = $res;
+            }
+        }
+        if ($config->fvd_enabled) {
+            my $res = system("/etc/init.d/oess-fvd status");
+            if ($res != 0) {
+                $result = $res;
+            }
+        }
+        if ($config->nox_enabled) {
+            my $res = system("/etc/init.d/oess-nox status");
+            if ($res != 0) {
+                $result = $res;
+            }
+        }
+        if ($config->traceroute_enabled) {
+            my $res = system("/etc/init.d/oess-traceroute status");
+            if ($res != 0) {
+                $result = $res;
+            }
+        }
+        if ($config->vlan_stats_enabled) {
+            my $res = system("/etc/init.d/oess-vlan_stats status");
+            if ($res != 0) {
+                $result = $res;
+            }
+        }
 
-	#END OF OPENFLOW only
-    }
+    } else {
 
-    if($db->is_mpls_enabled()){
-
-	if($db->is_mpls_fwdctl_enabled()){
-	    my $res = system("/etc/init.d/oess-mpls-fwdctl status");
-	    if($res != 0){
-		$result = $res;
-	    }
-	}
-
-	if($db->is_mpls_discovery_enabled()){
+        if ($config->mpls_discovery_enabled) {
             my $res = system("/etc/init.d/oess-mpls-discovery status");
-            if($res != 0){
+            if ($res != 0) {
+                $result = $res;
+            }
+        }
+        if ($config->mpls_fwdctl_enabled) {
+            my $res = system("/etc/init.d/oess-mpls-fwdctl status");
+            if ($res != 0) {
                 $result = $res;
             }
         }
 
-	#END OF MPLS only
     }
 
-    if($db->is_nsi_enabled()){
-	my $res = system("/etc/init.d/oess-nsi status");
-	if($res != 0){
-	    $result = $res;
-	}
-    }
-    
-    if($db->is_notification_enabled()){
+    if ($config->notification_enabled) {
         my $res = system("/etc/init.d/oess-notification status");
-        if($res != 0){
+        if ($res != 0) {
             $result = $res;
         }
     }
-    
-    if($db->is_watchdog_enabled()){
+    if ($config->nsi_enabled) {
+        my $res = system("/etc/init.d/oess-nsi status");
+        if ($res != 0) {
+            $result = $res;
+        }
+    }
+    if ($config->watchdog_enabled) {
         my $res = system("/etc/init.d/oess-watchdog status");
-        if($res != 0){
+        if ($res != 0) {
             $result = $res;
         }
     }
-    
 
     #cause this is how wait work?
     return $result / 256;
 
 }
 
-sub stop{
-    my $db = OESS::Database->new();
+sub stop {
     my $result = 0;
-    if($db->is_openflow_enabled()){
-	
-        if($db->is_fwdctl_enabled()){
+
+    if ($config->openflow_enabled) {
+
+        if ($config->fwdctl_enabled) {
             my $res = system("/etc/init.d/oess-fwdctl stop");
-            if($res != 0){
+            if ($res != 0) {
                 $result = $res;
             }
         }
-
-
-        if($db->is_vlan_stats_enabled()){
-            my $res = system("/etc/init.d/oess-vlan_stats stop");
-            if($res != 0){
-                $result = $res;
-            }
-        }
-        if($db->is_nox_enabled()){
-            my $res = system("/etc/init.d/nox_cored stop");
-            if($res != 0){
-                $result = $res;
-            }
-        }
-
-        if($db->is_fvd_enabled()){
+        if ($config->fvd_enabled) {
             my $res = system("/etc/init.d/oess-fvd stop");
-            if($res != 0){
+            if ($res != 0) {
                 $result = $res;
             }
         }
-
-        if($db->is_traceroute_enabled()){
+        if ($config->nox_enabled) {
+            my $res = system("/etc/init.d/oess-nox stop");
+            if ($res != 0) {
+                $result = $res;
+            }
+        }
+        if ($config->traceroute_enabled) {
             my $res = system("/etc/init.d/oess-traceroute stop");
-            if($res != 0){
+            if ($res != 0) {
+                $result = $res;
+            }
+        }
+        if ($config->vlan_stats_enabled) {
+            my $res = system("/etc/init.d/oess-vlan_stats stop");
+            if ($res != 0) {
                 $result = $res;
             }
         }
 
-        #END OF OPENFLOW only
-    }
+    } else {
 
-    if($db->is_mpls_enabled()){
-
-        if($db->is_mpls_fwdctl_enabled()){
-            my $res = system("/etc/init.d/oess-mpls-fwdctl stop");
-            if($res != 0){
-                $result = $res;
-            }
-        }
-
-        if($db->is_mpls_discovery_enabled()){
+        if ($config->mpls_discovery_enabled) {
             my $res = system("/etc/init.d/oess-mpls-discovery stop");
-            if($res != 0){
+            if ($res != 0) {
                 $result = $res;
             }
         }
-	
-        #END OF MPLS only
-    }
-
-    if($db->is_nsi_enabled()){
-        my $res = system("/etc/init.d/oess-nsi stop");
-        if($res != 0){
-            $result = $res;
+        if ($config->mpls_fwdctl_enabled) {
+            my $res = system("/etc/init.d/oess-mpls-fwdctl stop");
+            if ($res != 0) {
+                $result = $res;
+            }
         }
+
     }
 
-    if($db->is_notification_enabled()){
+    if ($config->notification_enabled) {
         my $res = system("/etc/init.d/oess-notification stop");
-        if($res != 0){
+        if ($res != 0) {
             $result = $res;
         }
     }
-
-    if($db->is_watchdog_enabled()){
+    if ($config->nsi_enabled) {
+        my $res = system("/etc/init.d/oess-nsi stop");
+        if ($res != 0) {
+            $result = $res;
+        }
+    }
+    if ($config->watchdog_enabled) {
         my $res = system("/etc/init.d/oess-watchdog stop");
-        if($res != 0){
+        if ($res != 0) {
             $result = $res;
         }
     }
 
     #cause this is how wait work?
     return $result / 256;
-
-
 }
 
-sub start{
-    my $db = OESS::Database->new();
-    
+sub start {
     my $result = 0;
 
-    if($db->is_openflow_enabled()){
+    if ($config->openflow_enabled) {
 
-        if($db->is_fwdctl_enabled()){
+        if ($config->fwdctl_enabled) {
             my $res = system("/etc/init.d/oess-fwdctl start");
-            if($res != 0){
+            if ($res != 0) {
                 $result = $res;
             }
         }
-
-        if($db->is_vlan_stats_enabled()){
-            my $res = system("/etc/init.d/oess-vlan_stats start");
-            if($res != 0){
-                $result = $res;
-            }
-        }
-        if($db->is_nox_enabled()){
-            my $res = system("/etc/init.d/nox_cored start");
-            if($res != 0){
-                $result = $res;
-            }
-        }
-
-        if($db->is_fvd_enabled()){
+        if ($config->fvd_enabled) {
             my $res = system("/etc/init.d/oess-fvd start");
-            if($res != 0){
+            if ($res != 0) {
                 $result = $res;
             }
         }
-
-        if($db->is_traceroute_enabled()){
+        if ($config->nox_enabled) {
+            my $res = system("/etc/init.d/oess-nox start");
+            if ($res != 0) {
+                $result = $res;
+            }
+        }
+        if ($config->traceroute_enabled) {
             my $res = system("/etc/init.d/oess-traceroute start");
-            if($res != 0){
+            if ($res != 0) {
+                $result = $res;
+            }
+        }
+        if ($config->vlan_stats_enabled) {
+            my $res = system("/etc/init.d/oess-vlan_stats start");
+            if ($res != 0) {
                 $result = $res;
             }
         }
 
-        #END OF OPENFLOW only
-    }
+    } else {
 
-
-    if($db->is_mpls_enabled()){
-
-        if($db->is_mpls_fwdctl_enabled()){
-            my $res = system("/etc/init.d/oess-mpls-fwdctl start");
-            if($res != 0){
-                $result = $res;
-            }
-        }
-
-        if($db->is_mpls_discovery_enabled()){
+        if ($config->mpls_discovery_enabled) {
             my $res = system("/etc/init.d/oess-mpls-discovery start");
-            if($res != 0){
+            if ($res != 0) {
+                $result = $res;
+            }
+        }
+        if ($config->mpls_fwdctl_enabled) {
+            my $res = system("/etc/init.d/oess-mpls-fwdctl start");
+            if ($res != 0) {
                 $result = $res;
             }
         }
 
-        #END OF MPLS only
     }
 
-    if($db->is_nsi_enabled()){
-        my $res = system("/etc/init.d/oess-nsi start");
-        if($res != 0){
-            $result = $res;
-        }
-    }
-
-    if($db->is_notification_enabled()){
+    if ($config->notification_enabled) {
         my $res = system("/etc/init.d/oess-notification start");
-        if($res != 0){
+        if ($res != 0) {
             $result = $res;
         }
     }
-
-    if($db->is_watchdog_enabled()){
+    if ($config->nsi_enabled) {
+        my $res = system("/etc/init.d/oess-nsi start");
+        if ($res != 0) {
+            $result = $res;
+        }
+    }
+    if ($config->watchdog_enabled) {
         my $res = system("/etc/init.d/oess-watchdog start");
-        if($res != 0){
+        if ($res != 0) {
             $result = $res;
         }
     }

--- a/app/oess_setup.pl
+++ b/app/oess_setup.pl
@@ -74,6 +74,7 @@ sub main{
     while (!($network_type = required_parameter('Network Stack: OpenFlow (1), VPN-MPLS (2), or EVPN-VXLAN (3)')) || !$network_types->{$network_type}) {
         print "Invalid network type '$network_type' selected. - Use 1, 2 or 3.\n";
     }
+    $network_type = $network_types->{$network_type};
 
     my $use_mpls = 'enabled';
     my $use_openflow = 'enabled';

--- a/app/oess_setup.pl
+++ b/app/oess_setup.pl
@@ -68,10 +68,26 @@ sub main{
           or !$allowed_modes{$of_mpls_mode}) {
         print "Invalid value $of_mpls_mode entered - use 1, 2, or 3.\n";
     }
-    my $use_openflow = 'enabled';
-    $use_openflow = 'disabled' if $of_mpls_mode == 2;
+
+    my $network_types = { '1' => 'openflow', '2' => 'vpn-mpls', '3' => 'evpn-vxlan' };
+    my $network_type;
+    while (!($network_type = required_parameter('Network Stack: OpenFlow (1), VPN-MPLS (2), or EVPN-VXLAN (3)')) || !$network_types->{$network_type}) {
+        print "Invalid network type '$network_type' selected. - Use 1, 2 or 3.\n";
+    }
+
     my $use_mpls = 'enabled';
-    $use_mpls = 'disabled' if $of_mpls_mode == 1;
+    my $use_openflow = 'enabled';
+
+    if ($network_type eq 'openflow') {
+        $use_mpls = 'disabled';
+    }
+    elsif ($network_type eq 'vpn-mpls') {
+        $use_openflow = 'disabled';
+    }
+    elsif ($network_type eq 'evpn-vxlan') {
+        $use_mpls = 'disabled';
+        $use_openflow = 'disabled';
+    }
 
     my $host = hostname;
     my $oscars_host = optional_parameter("Oscars Host URL","https://$host");
@@ -135,7 +151,7 @@ sub main{
 
     print FILE << "END";
 <config host="$db_host" port="$db_port" base_url="$base_url"
-        openflow="$use_openflow" mpls="$use_mpls">
+        openflow="$use_openflow" mpls="$use_mpls" network_type="$network_type">
   <tsds url="$tsds_url" username="$tsds_username" password="$tsds_password" />
   <grafana host="$grafana_url">
     <graph panelName="oess-interface"     uid="aaaaaaaaa" orgId="1" panelId="1"/>

--- a/frontend/webservice/vrf.cgi
+++ b/frontend/webservice/vrf.cgi
@@ -14,6 +14,7 @@ use GRNOC::WebService::Dispatcher;
 use OESS::RabbitMQ::Client;
 use OESS::Cloud;
 use OESS::Cloud::AWS;
+use OESS::Config;
 use OESS::DB;
 use OESS::DB::Entity;
 use OESS::VRF;
@@ -21,7 +22,7 @@ use OESS::VRF;
 
 Log::Log4perl::init_and_watch('/etc/oess/logging.conf',10);
 
-
+my $config = new OESS::Config();
 my $db = OESS::DB->new();
 my $svc = GRNOC::WebService::Dispatcher->new();
 my $mq = OESS::RabbitMQ::Client->new( topic    => 'OF.FWDCTL.RPC',
@@ -159,16 +160,20 @@ sub get_vrf_details{
     my $ref = shift;
 
     my $vrf_id = $params->{'vrf_id'}{'value'};
-    
+
+    if ($config->network_type ne 'vpn-mpls') {
+        $method->set_error("Support for Layer 3 Connections is currently disabled. Please contact your OESS administrator for more information.");
+        return;
+    }
+
     my $vrf = OESS::VRF->new(db => $db, vrf_id => $vrf_id);
-    
+
     if(!defined($vrf)){
         $method->set_error("VRF: " . $vrf_id . " was not found");
         return;
     }
 
     return {results => [$vrf->to_hash()]};
-    
 }
 
 sub get_vrfs{
@@ -177,6 +182,11 @@ sub get_vrfs{
     my $ref = shift;
 
     my $workgroup_id = $params->{'workgroup_id'}{'value'};
+
+    if ($config->network_type ne 'vpn-mpls') {
+        $method->set_error("Support for Layer 3 Connections is currently disabled. Please contact your OESS administrator for more information.");
+        return;
+    }
 
     #verify user is in workgroup
     my $user = OESS::DB::User::find_user_by_remote_auth( db => $db, remote_user => $ENV{'REMOTE_USER'} );
@@ -209,6 +219,11 @@ sub get_vrfs{
 sub provision_vrf{
     my $method = shift;
     my $params = shift;
+
+    if ($config->network_type ne 'vpn-mpls') {
+        $method->set_error("Support for Layer 3 Connections is currently disabled. Please contact your OESS administrator for more information.");
+        return;
+    }
 
     my $user = new OESS::User(db => $db, username => $ENV{REMOTE_USER});
     if (!defined $user) {
@@ -701,6 +716,11 @@ sub remove_vrf{
     my $method = shift;
     my $params = shift;
     my $ref = shift;
+
+    if ($config->network_type ne 'vpn-mpls') {
+        $method->set_error("Support for Layer 3 Connections is currently disabled. Please contact your OESS administrator for more information.");
+        return;
+    }
 
     my $model = {};
     my $user = new OESS::User(db => $db, username => $ENV{REMOTE_USER});

--- a/frontend/www/html_templates/base.html
+++ b/frontend/www/html_templates/base.html
@@ -43,8 +43,12 @@
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">New Connection <span class="caret"></span></a>
                 <ul class="dropdown-menu">
+                  [% IF network_type == 'evpn-vxlan' %]
+                  <li><a href="[% path %]new/index.cgi?action=provision_l2vpn">Layer 2</a></li>
+                  [% ELSE %]
                   <li><a href="[% path %]new/index.cgi?action=provision_l2vpn">Layer 2</a></li>
                   <li><a href="[% path %]new/index.cgi?action=provision_cloud">Layer 3</a></li>
+                  [% END %]
                 </ul>
               </li>
               <li><a href="[% path %]new/index.cgi?action=phonebook">Explore</a></li>

--- a/frontend/www/html_templates/welcome.html
+++ b/frontend/www/html_templates/welcome.html
@@ -10,6 +10,11 @@
   
   <br/>
 
+  [% IF network_type == 'evpn-vxlan' %]
+  <h3>Layer 2 Connections</h3>
+  <p>&nbsp;</p>
+  <div id="l2vpn-list"></div>
+  [% ELSE %]
   <h3>Layer 3 Connections</h3>
   <p>&nbsp;</p>
   <div id="entity-list"></div>
@@ -18,7 +23,7 @@
   <h3>Layer 2 Connections</h3>
   <p>&nbsp;</p>
   <div id="l2vpn-list"></div>
-
+  [% END %]
   <!-- waiting for deletion modal -->
   <div class="modal fade" role="dialog" tabindex="-1" id="delete-circuit-loading">
     <div class="modal-dialog" role="document">

--- a/frontend/www/index.cgi
+++ b/frontend/www/index.cgi
@@ -32,6 +32,7 @@
 #                                                 
 use strict;
 use warnings;
+use OESS::Config;
 use OESS::Database;
 use Data::Dumper;
 use CGI;
@@ -42,6 +43,7 @@ use Log::Log4perl;
 
 Log::Log4perl::init('/etc/oess/logging.conf');
 
+my $config = new OESS::Config();
 my $db= OESS::Database->new();
 
 
@@ -224,7 +226,7 @@ sub main{
     $vars->{'is_admin'}           = $is_admin;		    
     $vars->{'is_read_only'}       = $is_read_only;
     $vars->{'version'}            = OESS::Database::VERSION;
-    
+    $vars->{'network_type'}       = $config->network_type;
     
 	#print STDERR Dumper($vars);
     if ($action eq 'view_l3vpn' || $action eq 'provision_cloud' || $action eq 'modify_cloud' || $action eq 'phonebook' || $action eq 'welcome') {

--- a/frontend/www/js_templates/welcome.js
+++ b/frontend/www/js_templates/welcome.js
@@ -3,8 +3,12 @@ document.addEventListener('DOMContentLoaded', function() {
   let entityID = url.searchParams.get('entity_id');
 
   loadUserMenu().then(function() {
+    [% IF network_type == 'evpn-vxlan' %]
+    loadL2VPNs();
+    [% ELSE %]
     loadEntityList();
     loadL2VPNs();
+    [% END %]
   });
 });
 

--- a/frontend/www/new/index.cgi
+++ b/frontend/www/new/index.cgi
@@ -32,6 +32,7 @@
 #                                                 
 use strict;
 use warnings;
+use OESS::Config;
 use OESS::Database;
 use Data::Dumper;
 use CGI;
@@ -45,6 +46,7 @@ Log::Log4perl::init('/etc/oess/logging.conf');
 
 
 sub main{
+    my $config = new OESS::Config();
     my $db  = OESS::Database->new();
     my $cgi = new CGI;
     my $tt  = Template->new(INCLUDE_PATH => "$FindBin::Bin/..") || die $Template::ERROR;
@@ -66,6 +68,7 @@ sub main{
 	$vars->{'path'}               = "../";
         $vars->{'is_read_only'}       = 1;
         $vars->{'version'}            = OESS::Database::VERSION;
+        $vars->{'network_type'}       = $config->network_type;
 
         $tt->process("html_templates/base.html", $vars, \$output) or warn $tt->error();
         print "Content-type: text/html\n\n" . $output;
@@ -196,6 +199,7 @@ sub main{
     $vars->{'is_admin'}           = $is_admin;
     $vars->{'is_read_only'}       = $is_read_only;
     $vars->{'version'}            = OESS::Database::VERSION;
+    $vars->{'network_type'}       = $config->network_type;
 
     $tt->process("html_templates/base.html", $vars, \$output) or warn $tt->error();
     print "Content-type: text/html\n\n" . $output;

--- a/perl-lib/OESS/MANIFEST
+++ b/perl-lib/OESS/MANIFEST
@@ -40,6 +40,7 @@ lib/OESS/Measurement.pm
 lib/OESS/Mock.pm
 lib/OESS/MPLS/Device.pm
 lib/OESS/MPLS/Device/Juniper/MX.pm
+lib/OESS/MPLS/Device/Juniper/VXLAN.pm
 lib/OESS/MPLS/Discovery.pm
 lib/OESS/MPLS/Discovery/Interface.pm
 lib/OESS/MPLS/Discovery/ISIS.pm
@@ -85,6 +86,8 @@ share/customer-templates/juniper/srx/junos95/template.txt
 share/customer-templates/juniper/t/junos95/template.txt
 share/customer-templates/paloalto/pa3000/panos803/template.txt
 share/customer-templates/paloalto/pa5000/panos803/template.txt
+share/mpls/templates/juniper/13.3R8/EVPN/ep_config.xml
+share/mpls/templates/juniper/13.3R8/EVPN/ep_config_delete.xml
 share/mpls/templates/juniper/13.3R8/L2CCC/ep_config.xml
 share/mpls/templates/juniper/13.3R8/L2CCC/ep_config_delete.xml
 share/mpls/templates/juniper/13.3R8/L2VPLS/ep_config.xml

--- a/perl-lib/OESS/lib/OESS/Config.pm
+++ b/perl-lib/OESS/lib/OESS/Config.pm
@@ -138,7 +138,8 @@ sub network_type {
     }
 
     my $type = $self->{'config'}->{'network_type'};
-    foreach my $valid_type (['openflow', 'vpn-mpls', 'evpn-vxlan']) {
+    my $valid_types = ['openflow', 'vpn-mpls', 'evpn-vxlan'];
+    foreach my $valid_type (@$valid_types) {
         if ($type eq $valid_type) {
             return $type;
         }

--- a/perl-lib/OESS/lib/OESS/MPLS/Device.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device.pm
@@ -38,7 +38,10 @@ sub _get_credentials{
     my $self = shift;
     my $node_id = $self->{'node_id'};
     my $config = GRNOC::Config->new( config_file => OESS_PW_FILE );
-    my $node = $config->{'doc'}->getDocumentElement()->find("/config/node[\@node_id='$node_id']")->[0];
+    my $node;
+    if (defined $node_id) {
+        $node = $config->{'doc'}->getDocumentElement()->find("/config/node[\@node_id='$node_id']")->[0];
+    }
 
     my $creds;
     if(!defined($node)){

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -1759,6 +1759,7 @@ sub verify_connection{
         }
     }
 
+    warn "Network OS $sysinfo->{'os_name'} version $sysinfo->{'version'} on the $sysinfo->{'model'} is not supported.";
     $self->{'logger'}->error("Network OS $sysinfo->{'os_name'} version $sysinfo->{'version'} on the $sysinfo->{'model'} is not supported.");
     $self->disconnect();
     return 0;

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -823,7 +823,7 @@ sub remove_vlan{
       paths => [],
       circuit_id => 3012,
       site_id => 1,
-      ckt_type => 'L2VPLS'
+      ckt_type => 'L2VPLS' # EVPN, L2CCC, L2VPLS, L2VPN, or L3VPN
     });
 
 add_vlan adds a vlan to this device via NetConf. Returns 1 on success.

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/QFX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/QFX.pm
@@ -1,0 +1,69 @@
+use strict;
+use warnings;
+
+package OESS::MPLS::Device::Juniper::QFX;
+
+use parent 'OESS::MPLS::Device::Juniper::MX';
+
+use constant FWDCTL_WAITING     => 2;
+use constant FWDCTL_SUCCESS     => 1;
+use constant FWDCTL_FAILURE     => 0;
+use constant FWDCTL_UNKNOWN     => 3;
+use constant FWDCTL_BLOCKED     => 4;
+
+use Log::Log4perl;
+
+=head1 OESS::MPLS::Device::Juniper::QFX
+
+    use OESS::MPLS::Device::Juniper::QFX;
+
+=cut
+
+=head2 new
+
+    my $qfx = OESS::MPLS::Device::Juniper::QFX->new(
+      config => '/etc/oess/database.xml',
+      loopback_addr => '127.0.0.1',
+      mgmt_addr     => '192.168.1.1',
+      name          => 'demo.grnoc.iu.edu',
+      node_id       => 1
+    );
+
+new creates a Juniper QFX device object. Use methods on this object to
+communicate with a device on the network.
+
+=cut
+sub new {
+    my $class = shift;
+    my $args = {
+        @_
+    };
+
+    my $self = $class->SUPER::new(@_);
+    bless $self, $class;
+
+    $self->{logger} = Log::Log4perl->get_logger("OESS.MPLS.Device.Juniper.QFX.$self->{mgmt_addr}");
+    $self->{logger}->info("Juniper QFX Loaded: $self->{mgmt_addr}");
+
+    return $self;
+}
+
+=head2 add_vrf
+
+=cut
+sub add_vrf {
+    my $self = shift;
+    $self->{logger}->error('Layer 3 Connections are not supported on QFX devices.');
+    return FWDCTL_FAILURE;
+}
+
+=head2 remove_vrf
+
+=cut
+sub remove_vrf {
+    my $self = shift;
+    $self->{logger}->error('Layer 3 Connections are not supported on QFX devices.');
+    return FWDCTL_FAILURE;
+}
+
+return 1;

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/VXLAN.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/VXLAN.pm
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-package OESS::MPLS::Device::Juniper::QFX;
+package OESS::MPLS::Device::Juniper::VXLAN;
 
 use parent 'OESS::MPLS::Device::Juniper::MX';
 
@@ -13,15 +13,15 @@ use constant FWDCTL_BLOCKED     => 4;
 
 use Log::Log4perl;
 
-=head1 OESS::MPLS::Device::Juniper::QFX
+=head1 OESS::MPLS::Device::Juniper::VXLAN
 
-    use OESS::MPLS::Device::Juniper::QFX;
+    use OESS::MPLS::Device::Juniper::VXLAN;
 
 =cut
 
 =head2 new
 
-    my $qfx = OESS::MPLS::Device::Juniper::QFX->new(
+    my $VXLAN = OESS::MPLS::Device::Juniper::VXLAN->new(
       config => '/etc/oess/database.xml',
       loopback_addr => '127.0.0.1',
       mgmt_addr     => '192.168.1.1',
@@ -29,7 +29,7 @@ use Log::Log4perl;
       node_id       => 1
     );
 
-new creates a Juniper QFX device object. Use methods on this object to
+new creates a Juniper VXLAN device object. Use methods on this object to
 communicate with a device on the network.
 
 =cut
@@ -42,8 +42,8 @@ sub new {
     my $self = $class->SUPER::new(@_);
     bless $self, $class;
 
-    $self->{logger} = Log::Log4perl->get_logger("OESS.MPLS.Device.Juniper.QFX.$self->{mgmt_addr}");
-    $self->{logger}->info("Juniper QFX Loaded: $self->{mgmt_addr}");
+    $self->{logger} = Log::Log4perl->get_logger("OESS.MPLS.Device.Juniper.VXLAN.$self->{mgmt_addr}");
+    $self->{logger}->info("Juniper VXLAN Loaded: $self->{mgmt_addr}");
 
     return $self;
 }
@@ -53,7 +53,7 @@ sub new {
 =cut
 sub add_vrf {
     my $self = shift;
-    $self->{logger}->error('Layer 3 Connections are not supported on QFX devices.');
+    $self->{logger}->error('Layer 3 Connections are not supported on VXLAN devices.');
     return FWDCTL_FAILURE;
 }
 
@@ -62,7 +62,7 @@ sub add_vrf {
 =cut
 sub remove_vrf {
     my $self = shift;
-    $self->{logger}->error('Layer 3 Connections are not supported on QFX devices.');
+    $self->{logger}->error('Layer 3 Connections are not supported on VXLAN devices.');
     return FWDCTL_FAILURE;
 }
 

--- a/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
@@ -50,6 +50,7 @@ use GRNOC::WebService::Regex;
 use OESS::Database;
 use JSON::XS;
 
+use OESS::Config;
 use OESS::MPLS::Discovery::Interface;
 use OESS::MPLS::Discovery::LSP;
 use OESS::MPLS::Discovery::ISIS;
@@ -94,14 +95,14 @@ sub new{
 
     bless $self, $class;
 
-    if (!defined $self->{'config'}) {
-        $self->{'config'} = "/etc/oess/database.xml";
-    }
+    my $config_filename = '/etc/oess/database.xml';
+    $self->{'config'} = OESS::Config(config_filename => $config_filename);
+
     if (!defined $self->{'test'}) {
         $self->{'test'} = 0;
     }
 
-    $self->{'db'} = OESS::Database->new(config => $self->{'config'});
+    $self->{'db'} = OESS::Database->new(config => $config_filename);
     die if (!defined $self->{'db'});
 
     $self->{'interface'} = $self->_init_interfaces();
@@ -128,7 +129,7 @@ sub new{
 
     # Create the client for talking to our Discovery switch objects!
     $self->{'rmq_client'} = OESS::RabbitMQ::Client->new(
-        config => $self->{'config'},
+        config => $config_filename,
         timeout => 120,
         topic => 'MPLS.Discovery'
     );
@@ -147,12 +148,14 @@ sub new{
 
     $self->{'device_timer'} = AnyEvent->timer( after => 10, interval => 60, cb => sub { $self->device_handler(); });
     $self->{'int_timer'} = AnyEvent->timer( after => 60, interval => 120, cb => sub { $self->int_handler(); });
-    $self->{'lsp_timer'} = AnyEvent->timer( after => 70, interval => 200, cb => sub { $self->lsp_handler(); });
-    $self->{'isis_timer'} = AnyEvent->timer( after => 80, interval => 120, cb => sub { $self->isis_handler(); } );
-    $self->{'path_timer'} = AnyEvent->timer( after => 40, interval => 300, cb => sub { $self->path_handler(); });
-    $self->{'vrf_stats_time'} = AnyEvent->timer( after => 20, interval => VRF_STATS_INTERVAL, cb => sub {
-        $self->vrf_stats_handler();
-    });
+    $self->{'isis_timer'} = AnyEvent->timer( after => 80, interval => 120, cb => sub { $self->isis_handler(); });
+    $self->{'vrf_stats_time'} = AnyEvent->timer( after => 20, interval => VRF_STATS_INTERVAL, cb => sub { $self->vrf_stats_handler(); });
+
+    # Only lookup LSPs and Paths when network type is vpn-mpls.
+    if ($self->{'config'}->network_type eq 'vpn-mpls') {
+        $self->{'lsp_timer'} = AnyEvent->timer( after => 70, interval => 200, cb => sub { $self->lsp_handler(); });
+        $self->{'path_timer'} = AnyEvent->timer( after => 40, interval => 300, cb => sub { $self->path_handler(); });
+    }
 
     # Dispatcher for receiving events (eg. A new switch was created).
     $self->{'dispatcher'} = OESS::RabbitMQ::Dispatcher->new(
@@ -347,7 +350,9 @@ sub _init_paths{
 =cut
 sub int_handler{
     my $self = shift;
-    
+
+    $self->{'logger'}->info("Calling get_interfaces!");
+
     foreach my $node (@{$self->{'db'}->get_current_nodes(type => 'mpls')}) {
 	$self->{'rmq_client'}->{'topic'} = "MPLS.Discovery.Switch." . $node->{'mgmt_addr'};
 	my $start = [gettimeofday];
@@ -374,12 +379,14 @@ sub int_handler{
 
 =cut
 sub path_handler {
-
     my $self = shift;
 
-    warn "IN Path handler\n";
+    if ($self->{'config'}->network_type ne 'vpn-mpls') {
+        # Only lookup Paths when network type is set to vpn-mpls.
+        return 1;
+    }
 
-    $self->{'logger'}->info("path_handler: calling");
+    $self->{'logger'}->info("Calling get_routed_lsps and get_lsp_paths!");
 
     my $nodes = $self->{'db'}->get_current_nodes(type => 'mpls');
     if (!defined $nodes) {
@@ -449,7 +456,14 @@ sub path_handler {
 =cut
 sub lsp_handler{
     my $self = shift;
-    
+
+    if ($self->{'config'}->network_type ne 'vpn-mpls') {
+        # Only lookup LSPs when network type is set to vpn-mpls.
+        return 1;
+    }
+
+    $self->{'logger'}->info("Calling get_LSPs!");
+
     my %nodes;
 
     foreach my $node (@{$self->{'db'}->get_current_nodes(type => 'mpls')}) {
@@ -484,6 +498,7 @@ sub lsp_handler{
 sub isis_handler{
     my $self = shift;
 
+    $self->{'logger'}->info("Calling get_isis_adjacencies!");
 
     my %nodes;
     foreach my $node (@{$self->{'db'}->get_current_nodes(type => 'mpls')}) {
@@ -517,6 +532,9 @@ sub isis_handler{
 =cut
 sub device_handler{
     my $self =shift;
+
+    $self->{'logger'}->info("Calling get_system_info!");
+
     foreach my $node (@{$self->{'db'}->get_current_nodes(type => 'mpls')}) {
         $self->{'rmq_client'}->{'topic'} = "MPLS.Discovery.Switch." . $node->{'mgmt_addr'};
 	my $start = [gettimeofday];
@@ -540,7 +558,9 @@ sub device_handler{
 =cut
 sub vrf_stats_handler{
     my $self = shift;
-    $self->{'logger'}->debug("Attempting to pull VRF stats");
+
+    $self->{'logger'}->info("Calling get_vrf_stats!");
+
     foreach my $node (@{$self->{'db'}->get_current_nodes(type => 'mpls')}) {
 	$self->{'rmq_client'}->{'topic'} = "MPLS.Discovery.Switch." . $node->{'mgmt_addr'};
 	my $start = [gettimeofday];

--- a/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
@@ -95,7 +95,7 @@ sub new{
 
     bless $self, $class;
 
-    my $config_filename = '/etc/oess/database.xml';
+    my $config_filename = (defined $self->{'config'}) ? $self->{'config'} : '/etc/oess/database.xml';
     $self->{'config'} = new OESS::Config(config_filename => $config_filename);
 
     if (!defined $self->{'test'}) {

--- a/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
@@ -96,7 +96,7 @@ sub new{
     bless $self, $class;
 
     my $config_filename = '/etc/oess/database.xml';
-    $self->{'config'} = OESS::Config(config_filename => $config_filename);
+    $self->{'config'} = new OESS::Config(config_filename => $config_filename);
 
     if (!defined $self->{'test'}) {
         $self->{'test'} = 0;

--- a/perl-lib/OESS/lib/OESS/MPLS/FWDCTL.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/FWDCTL.pm
@@ -8,6 +8,7 @@ use Data::Dumper;
 use Log::Log4perl;
 use Socket;
 
+use OESS::Config;
 use OESS::Database;
 use OESS::Topology;
 use OESS::Circuit;
@@ -69,11 +70,10 @@ sub new {
 
     $self->{'logger'} = Log::Log4perl->get_logger('OESS.MPLS.FWDCTL.MASTER');
 
-    if(!defined($self->{'config'})){
-        $self->{'config'} = "/etc/oess/database.xml";
-    }
+    my $config_filename = (defined $self->{'config'}) ? $self->{'config'} : '/etc/oess/database.xml';
+    $self->{'config'} = new OESS::Config(config_filename => $config_filename);
 
-    $self->{'db'} = OESS::Database->new( config_file => $self->{'config'} );
+    $self->{'db'} = OESS::Database->new( config_file => $config_filename );
     $self->{'db2'} = OESS::DB->new();
     my $fwdctl_dispatcher = OESS::RabbitMQ::Dispatcher->new( queue => 'MPLS-FWDCTL',
                                                              topic => "MPLS.FWDCTL.RPC");
@@ -304,31 +304,36 @@ sub _write_cache{
         my $details = $ckt->to_hash();
         my $eps = $ckt->endpoints();
 
-        my $ckt_type = "L2VPN";
+        my $ckt_type;
+        if ($self->{'config'}->network_type eq 'evpn-vxlan') {
+            $ckt_type = "EVPN";
+        } else {
+            $ckt_type = "L2VPN";
 
-        my $primary_path = $ckt->path(type => 'primary');
-        if (defined $primary_path && @{$primary_path->links} > 0) {
-            $ckt_type = "L2CCC";
+            my $primary_path = $ckt->path(type => 'primary');
+            if (defined $primary_path && @{$primary_path->links} > 0) {
+                $ckt_type = "L2CCC";
+            }
+
+            if(scalar(@$eps) > 2){
+                $ckt_type = "L2VPLS";
+            }
         }
 
-        if(scalar(@$eps) > 2){
-            $ckt_type = "L2VPLS";
-        }
-
-	my $site_id = 0;
-	foreach my $ep_a (@$eps){
+        my $site_id = 0;
+        foreach my $ep_a (@$eps){
             my @ints;
             push(@ints, $ep_a->to_hash);
 
-	    $site_id++;
-	    my $paths = [];
+            $site_id++;
+            my $paths = [];
             my $touch = {};
 
-	    if(defined($switches{$ep_a->{'node'}}->{'ckts'}{$details->{'circuit_id'}})){
-		next;
-	    }
+            if(defined($switches{$ep_a->{'node'}}->{'ckts'}{$details->{'circuit_id'}})){
+                next;
+            }
 
-	    foreach my $ep_z (@$eps){
+            foreach my $ep_z (@$eps){
 
                 # Ignore interations comparing the same endpoint.
                 next if ($ep_a->{'node'} eq $ep_z->{'node'} && $ep_a->{'interface'} eq $ep_z->{'interface'} && $ep_a->{'tag'} eq $ep_z->{'tag'} && $ep_a->{'inner_tag'} eq $ep_z->{'inner_tag'});
@@ -639,7 +644,7 @@ sub make_baby {
     my $node = $self->{'node_by_id'}->{$id};
     my %args;
     $args{'id'} = $id;
-    $args{'config'} = $self->{'config'};
+    $args{'config'} = $self->{'config'}->{'config_filename'};
     $args{'share_file'} = $self->{'share_file'}. "." . $id;
     $args{'rabbitMQ_host'} = $self->{'db'}->{'rabbitMQ'}->{'host'};
     $args{'rabbitMQ_port'} = $self->{'db'}->{'rabbitMQ'}->{'port'};

--- a/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
@@ -137,10 +137,13 @@ sub create_device_object{
     switch($host_info->{'vendor'}){
         case "Juniper" {
             my $dev;
-            if($host_info->{'model'} =~ /mx/i){
+            if ($host_info->{'model'} =~ /mx/i) {
                 $self->{'logger'}->debug("create_device_object: " . Dumper($host_info));
                 $dev = OESS::MPLS::Device::Juniper::MX->new( %$host_info );
-            }else{
+            } elsif ($host_info->{'model'} =~ /qfx/i){
+                $self->{'logger'}->debug("create_device_object: " . Dumper($host_info));
+                $dev = OESS::MPLS::Device::Juniper::MX->new( %$host_info );
+            } else {
                 $self->{'logger'}->error("Juniper " . $host_info->{'model'} . " is not supported");
                 return;
             }

--- a/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
@@ -22,10 +22,10 @@ use GRNOC::RabbitMQ::Method;
 use GRNOC::RabbitMQ::Client;
 use GRNOC::WebService::Regex;
 
-
+use OESS::Config;
 use OESS::MPLS::Device;
 use OESS::MPLS::Device::Juniper::MX;
-use OESS::MPLS::Device::Juniper::QFX;
+use OESS::MPLS::Device::Juniper::VXLAN;
 
 use JSON::XS;
 
@@ -50,6 +50,7 @@ sub new{
 
     $self->{'logger'} = Log::Log4perl->get_logger('OESS.MPLS.Switch.' . $self->{'id'});
     $self->{'config'} = $args{'config'} || '/etc/oess/database.xml';
+    $self->{'config_obj'} = new OESS::Config(config_filename => $self->{'config'});
 
     $self->{'node'}->{'node_id'} = $self->{'id'};
     
@@ -135,16 +136,19 @@ sub create_device_object{
 
     my $host_info = $self->{'node'};
     $host_info->{'config'} = $self->{'config'};
+$self->{logger}->error(Dumper($host_info));
 
     switch($host_info->{'vendor'}){
         case "Juniper" {
             my $dev;
             if ($host_info->{'model'} =~ /mx/i) {
-                $self->{'logger'}->debug("create_device_object: " . Dumper($host_info));
-                $dev = OESS::MPLS::Device::Juniper::MX->new( %$host_info );
-            } elsif ($host_info->{'model'} =~ /qfx/i){
-                $self->{'logger'}->debug("create_device_object: " . Dumper($host_info));
-                $dev = OESS::MPLS::Device::Juniper::QFX->new( %$host_info );
+                if ($self->{'config_obj'}->network_type eq 'evpn-vxlan') {
+                    $self->{'logger'}->debug("create_device_object: " . Dumper($host_info));
+                    $dev = OESS::MPLS::Device::Juniper::VXLAN->new( %$host_info );
+                } else {
+                    $self->{'logger'}->debug("create_device_object: " . Dumper($host_info));
+                    $dev = OESS::MPLS::Device::Juniper::MX->new( %$host_info );
+                }
             } else {
                 $self->{'logger'}->error("Juniper " . $host_info->{'model'} . " is not supported");
                 return;

--- a/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
@@ -24,6 +24,8 @@ use GRNOC::WebService::Regex;
 
 
 use OESS::MPLS::Device;
+use OESS::MPLS::Device::Juniper::MX;
+use OESS::MPLS::Device::Juniper::QFX;
 
 use JSON::XS;
 
@@ -142,7 +144,7 @@ sub create_device_object{
                 $dev = OESS::MPLS::Device::Juniper::MX->new( %$host_info );
             } elsif ($host_info->{'model'} =~ /qfx/i){
                 $self->{'logger'}->debug("create_device_object: " . Dumper($host_info));
-                $dev = OESS::MPLS::Device::Juniper::MX->new( %$host_info );
+                $dev = OESS::MPLS::Device::Juniper::QFX->new( %$host_info );
             } else {
                 $self->{'logger'}->error("Juniper " . $host_info->{'model'} . " is not supported");
                 return;

--- a/perl-lib/OESS/perl-OESS.spec
+++ b/perl-lib/OESS/perl-OESS.spec
@@ -115,6 +115,7 @@ rm -rf $RPM_BUILD_ROOT
 make pure_install
 %__mkdir -p -m 0775 $RPM_BUILD_ROOT%{docdir}/share/upgrade
 %__mkdir -p -m 0775 $RPM_BUILD_ROOT%{docdir}/share/customer-templates
+%__mkdir -p -m 0775 $RPM_BUILD_ROOT%{docdir}/share/mpls/templates/juniper/13.3R8/EVPN
 %__mkdir -p -m 0775 $RPM_BUILD_ROOT%{docdir}/share/mpls/templates/juniper/13.3R8/L2CCC
 %__mkdir -p -m 0775 $RPM_BUILD_ROOT%{docdir}/share/mpls/templates/juniper/13.3R8/L2VPLS
 %__mkdir -p -m 0775 $RPM_BUILD_ROOT%{docdir}/share/mpls/templates/juniper/13.3R8/L2VPN
@@ -129,6 +130,7 @@ make pure_install
 %__install share/nddi.sql $RPM_BUILD_ROOT/%{docdir}/share/
 %__install share/upgrade/* $RPM_BUILD_ROOT/%{docdir}/share/upgrade/
 cp -ar share/customer-templates/* $RPM_BUILD_ROOT/%{docdir}/share/customer-templates/
+%__install share/mpls/templates/juniper/13.3R8/EVPN/* $RPM_BUILD_ROOT/%{docdir}/share/mpls/templates/juniper/13.3R8/EVPN
 %__install share/mpls/templates/juniper/13.3R8/L2CCC/* $RPM_BUILD_ROOT/%{docdir}/share/mpls/templates/juniper/13.3R8/L2CCC
 %__install share/mpls/templates/juniper/13.3R8/L2VPLS/* $RPM_BUILD_ROOT/%{docdir}/share/mpls/templates/juniper/13.3R8/L2VPLS
 %__install share/mpls/templates/juniper/13.3R8/L2VPN/* $RPM_BUILD_ROOT/%{docdir}/share/mpls/templates/juniper/13.3R8/L2VPN
@@ -185,6 +187,7 @@ rm -rf $RPM_BUILD_ROOT
 %doc %{_mandir}/man3/OESS::FWDCTL::Switch.3pm.gz
 %doc %{_mandir}/man3/OESS::Measurement.3pm.gz
 %doc %{_mandir}/man3/OESS::MPLS::Device::Juniper::MX.3pm.gz
+%doc %{_mandir}/man3/OESS::MPLS::Device::Juniper::VXLAN.3pm.gz
 %doc %{_mandir}/man3/OESS::MPLS::Device.3pm.gz
 %doc %{_mandir}/man3/OESS::MPLS::Discovery::Interface.3pm.gz
 %doc %{_mandir}/man3/OESS::MPLS::Discovery::ISIS.3pm.gz
@@ -257,6 +260,7 @@ rm -rf $RPM_BUILD_ROOT
 %{perl_vendorlib}/OESS/FWDCTL/Switch.pm
 %{perl_vendorlib}/OESS/Measurement.pm
 %{perl_vendorlib}/OESS/MPLS/Device/Juniper/MX.pm
+%{perl_vendorlib}/OESS/MPLS/Device/Juniper/VXLAN.pm
 %{perl_vendorlib}/OESS/MPLS/Device.pm
 %{perl_vendorlib}/OESS/MPLS/Discovery/Interface.pm
 %{perl_vendorlib}/OESS/MPLS/Discovery/ISIS.pm
@@ -285,6 +289,7 @@ rm -rf $RPM_BUILD_ROOT
 %{docdir}/share/nddi.sql
 %{docdir}/share/upgrade/*
 %{docdir}/share/customer-templates/*
+%{docdir}/share/mpls/templates/juniper/13.3R8/EVPN/*
 %{docdir}/share/mpls/templates/juniper/13.3R8/L2CCC/*
 %{docdir}/share/mpls/templates/juniper/13.3R8/L2VPLS/*
 %{docdir}/share/mpls/templates/juniper/13.3R8/L2VPN/*

--- a/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/EVPN/ep_config.xml
+++ b/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/EVPN/ep_config.xml
@@ -1,0 +1,62 @@
+<configuration><groups><name>OESS</name>
+
+  <interfaces>
+    [% FOREACH interface IN interfaces %]
+    <interface>
+      <name>[% interface.interface %]</name>
+      <unit>
+        <name>[% interface.unit %]</name>
+        <description>OESS-EVPN-[% circuit_id %]</description>
+        <encapsulation>vlan-bridge</encapsulation>
+        [% IF interface.defined('inner_tag') %]
+        <vlan-tags>
+          <outer>[% interface.tag %]</outer>
+          <inner>[% interface.inner_tag %]</inner>
+        </vlan-tags>
+        [% ELSE %]
+        <vlan-id>[% interface.tag %]</vlan-id>
+        [% END %]
+        <output-vlan-map>
+          <swap/>
+        </output-vlan-map>
+      </unit>
+    </interface>
+    [% END %]
+  </interfaces>
+
+  <routing-instances>
+    <instance>
+      <name>OESS-EVPN-[% circuit_id %]</name>
+      <vtep-source-interface>
+        <interface-name>lo0.0</interface-name>
+      </vtep-source-interface>
+      <instance-type>evpn</instance-type>
+      <vlan-id>none</vlan-id>
+
+      [% FOREACH interface IN interfaces %]
+      <interface>
+	    <name>[% interface.interface %].[% interface.unit %]</name>
+      </interface>
+      [% END %]
+
+      <vxlan>
+        <vni>[% circuit_id %]</vni>
+        <encapsulate-inner-vlan inactive="inactive"/>
+        <decapsulate-accept-inner-vlan inactive="inactive"/>
+      </vxlan>
+      <no-normalization/>
+      <route-distinguisher>
+        <rd-type>65150:[% circuit_id %]</rd-type>
+      </route-distinguisher>
+      <vrf-target>
+        <community>target:65150:[% circuit_id %]</community>
+      </vrf-target>
+      <protocols>
+        <evpn>
+          <encapsulation>vxlan</encapsulation>
+        </evpn>
+      </protocols>
+    </instance>
+  </routing-instances>
+
+</groups></configuration>

--- a/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/EVPN/ep_config_delete.xml
+++ b/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/EVPN/ep_config_delete.xml
@@ -1,0 +1,20 @@
+<configuration><groups><name>OESS</name>
+
+  <interfaces>
+    [% FOREACH interface IN interfaces %]
+    <interface>
+      <name>[% interface.interface %]</name>
+      <unit operation='delete'>
+	    <name>[% interface.unit %]</name>
+      </unit>
+    </interface>
+    [% END %]
+  </interfaces>
+
+  <routing-instances>
+    <instance operation='delete'>
+      <name>OESS-EVPN-[% circuit_id %]</name>
+    </instance>
+  </routing-instances>
+
+</groups></configuration>


### PR DESCRIPTION
Adding support for EVPN-VXLAN based layer 2 connections. To enable, set the `network_type` attribute on the `config` tag in `/etc/oess/database.xml` to `evpn-vxlan`. Supported network types are `openflow`, `vpn-mpls`, or `evpn-vxlan`.

- `vpn-mpls` supports layer 2 and layer 3 connections
- `evpn-vxlan` only supports layer 2 connections

Fixes #948 