### PR TITLE
Adding class-of-service tags to layer2 connections

### DIFF
--- a/perl-lib/OESS/lib/OESS/DB/Endpoint.pm
+++ b/perl-lib/OESS/lib/OESS/DB/Endpoint.pm
@@ -370,6 +370,7 @@ sub add_circuit_edge_membership{
     my $result = $db->execute_query(
         "INSERT INTO circuit_edge_interface_membership (".
             "interface_id, ".
+            "bandwidth, ".
             "circuit_id, ".
             "end_epoch, ".
             "start_epoch, ".
@@ -379,6 +380,7 @@ sub add_circuit_edge_membership{
             "mtu ".
             ") VALUES (?, ?, ?, UNIX_TIMESTAMP(NOW()), ?, ?, ?, ?)",
             [$endpoint->{interface_id},
+             $endpoint->{bandwidth},
              $endpoint->{circuit_id},
              -1,
              $endpoint->{tag},

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -783,6 +783,7 @@ sub remove_vlan{
     foreach my $i (@{$ckt->{'interfaces'}}) {
         push (@{$vars->{'interfaces'}}, { interface => $i->{'interface'},
                                           inner_tag => $i->{'inner_tag'},
+                                          bandwidth => $i->{'bandwidth'} || 0,
                                           tag => $i->{'tag'},
                                           unit => $i->{'unit'}
                                         });
@@ -848,6 +849,7 @@ sub add_vlan{
 
         push (@{$vars->{'interfaces'}}, { interface => $i->{'interface'},
                                           inner_tag => $i->{'inner_tag'},
+                                          bandwidth => $i->{'bandwidth'} || 0,
                                           tag  => $i->{'tag'},
                                           unit => $i->{'unit'}
                                       });

--- a/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2CCC/ep_config.xml
+++ b/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2CCC/ep_config.xml
@@ -22,6 +22,22 @@
     </interface>
     [% END %]
   </interfaces>
+  [%- FOREACH interface IN interfaces -%]
+  [%- IF interface.bandwidth > 0 %]
+  <class-of-service>
+    <interfaces>
+      <interface>
+        <name>[% interface.interface %]</name>
+        <unit>
+          <name>[% interface.unit %]</name>
+          <shaping-rate><rate>[% interface.bandwidth %]m</rate></shaping-rate>
+        </unit>
+      </interface>
+    </interfaces>
+  </class-of-service>
+  [%- END -%]
+  [%- END %]
+
   <protocols>
     <mpls>
       <label-switched-path>

--- a/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2CCC/ep_config_delete.xml
+++ b/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2CCC/ep_config_delete.xml
@@ -9,6 +9,20 @@
     </interface>
     [% END %]
   </interfaces>
+  [%- FOREACH interface IN interfaces -%]
+  [%- IF interface.bandwidth > 0 %]
+  <class-of-service>
+    <interfaces>
+      <interface>
+        <name>[% interface.interface %]</name>
+        <unit operation='delete'>
+          <name>[% interface.unit %]</name>
+        </unit>
+      </interface>
+    </interfaces>
+  </class-of-service>
+  [%- END -%]
+  [%- END %]
   <protocols>
     <mpls>
       <label-switched-path operation='delete'>

--- a/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2VPLS/ep_config.xml
+++ b/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2VPLS/ep_config.xml
@@ -22,6 +22,21 @@
     </interface>
     [% END %]
   </interfaces>
+  [%- FOREACH interface IN interfaces -%]
+  [%- IF interface.bandwidth > 0 %]
+  <class-of-service>
+    <interfaces>
+      <interface>
+        <name>[% interface.interface %]</name>
+        <unit>
+          <name>[% interface.unit %]</name>
+          <shaping-rate><rate>[% interface.bandwidth %]m</rate></shaping-rate>
+        </unit>
+      </interface>
+    </interfaces>
+  </class-of-service>
+  [%- END -%]
+  [%- END %]
   <routing-instances>
     <instance>
       <name>OESS-L2VPLS-[% circuit_id %]</name>

--- a/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2VPLS/ep_config_delete.xml
+++ b/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2VPLS/ep_config_delete.xml
@@ -9,6 +9,20 @@
     </interface>
     [% END %]
   </interfaces>
+  [%- FOREACH interface IN interfaces -%]
+  [%- IF interface.bandwidth > 0 %]
+  <class-of-service>
+    <interfaces>
+      <interface>
+        <name>[% interface.interface %]</name>
+        <unit operation='delete'>
+          <name>[% interface.unit %]</name>
+        </unit>
+      </interface>
+    </interfaces>
+  </class-of-service>
+  [%- END -%]
+  [%- END %]
   [% IF paths.size > 0 %]
   <protocols>
     <mpls>

--- a/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2VPN/ep_config.xml
+++ b/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2VPN/ep_config.xml
@@ -22,6 +22,21 @@
     </interface>
     [% END %]
   </interfaces>
+  [%- FOREACH interface IN interfaces -%]
+  [%- IF interface.bandwidth > 0 %]
+  <class-of-service>
+    <interfaces>
+      <interface>
+        <name>[% interface.interface %]</name>
+        <unit>
+          <name>[% interface.unit %]</name>
+          <shaping-rate><rate>[% interface.bandwidth %]m</rate></shaping-rate>
+        </unit>
+      </interface>
+    </interfaces>
+  </class-of-service>
+  [%- END -%]
+  [%- END %]
   <routing-instances>
     <instance>
       <name>OESS-L2VPN-[% circuit_id %]</name>

--- a/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2VPN/ep_config_delete.xml
+++ b/perl-lib/OESS/share/mpls/templates/juniper/13.3R8/L2VPN/ep_config_delete.xml
@@ -9,6 +9,20 @@
     </interface>
     [% END %]
   </interfaces>
+  [%- FOREACH interface IN interfaces -%]
+  [%- IF interface.bandwidth > 0 %]
+  <class-of-service>
+    <interfaces>
+      <interface>
+        <name>[% interface.interface %]</name>
+        <unit operation='delete'>
+          <name>[% interface.unit %]</name>
+        </unit>
+      </interface>
+    </interfaces>
+  </class-of-service>
+  [%- END -%]
+  [%- END %]
   <routing-instances>
     <instance operation='delete'>
       <name>OESS-L2VPN-[% circuit_id %]</name>

--- a/perl-lib/OESS/t/mpls/mx-add_vlan.t
+++ b/perl-lib/OESS/t/mpls/mx-add_vlan.t
@@ -126,7 +126,8 @@ $ok = $device->add_vlan({
         {
             interface => 'ge-0/0/2',
             tag => 2004,
-            unit => 2004
+            unit => 2004,
+            bandwidth => 50
         }
     ],
     paths => [],
@@ -220,6 +221,17 @@ my $expected_config = '<configuration><groups><name>OESS</name>
     </interface>
     
   </interfaces>
+  <class-of-service>
+    <interfaces>
+      <interface>
+        <name>ge-0/0/2</name>
+        <unit>
+          <name>2004</name>
+          <shaping-rate><rate>50m</rate></shaping-rate>
+        </unit>
+      </interface>
+    </interfaces>
+  </class-of-service>
   <routing-instances>
     <instance>
       <name>OESS-L2VPLS-3012</name>

--- a/perl-lib/OESS/t/mpls/mx-remove_vlan.t
+++ b/perl-lib/OESS/t/mpls/mx-remove_vlan.t
@@ -105,7 +105,8 @@ $ok = $device->remove_vlan({
         {
             interface => 'ge-0/0/2',
             unit => 2004,
-            tag => 2004
+            tag => 2004,
+            bandwidth => 50
         }
     ],
     paths => [],
@@ -183,6 +184,16 @@ my $expected_config = "<configuration><groups><name>OESS</name>
     </interface>
     
   </interfaces>
+  <class-of-service>
+    <interfaces>
+      <interface>
+        <name>ge-0/0/2</name>
+        <unit operation=\'delete\'>
+          <name>2004</name>
+        </unit>
+      </interface>
+    </interfaces>
+  </class-of-service>
   
   <protocols>
     <mpls>


### PR DESCRIPTION
If bandwidth is defined on a layer2 connection Endpoint we include a
class-of-service tag in our provisioning request to the network
device. This change also ensures that the user specified bandwidth is
stored in the db. Prior to this change, bandwidth was ignored except
on layer3 connections.