### PR TITLE
adding logic to skip tertiary path updates on circuit edits

### DIFF
--- a/perl-lib/OESS/lib/OESS/Database.pm
+++ b/perl-lib/OESS/lib/OESS/Database.pm
@@ -8575,6 +8575,14 @@ sub edit_circuit {
     my $paths = $self->_execute_query($query, [$circuit_id]);
 
     foreach my $path (@$paths){
+        if ($path->{'path_type'} eq 'tertiary') {
+            # Default or tertiary paths are defined by the
+            # network. For this reason, the only user generated action
+            # that should modify tertiary paths is circuit
+            # decommissions.
+            next;
+        }
+
         $query = "update path_instantiation set end_epoch = unix_timestamp(now()) where path_id = ? and end_epoch = -1";
         if(!defined($self->_execute_query($query, [$path->{'path_id'}]))){
             $self->_set_error("Unable to decom path_instantiations");


### PR DESCRIPTION
Default or tertiary paths are defined by the network. For this reason,
the only user generated action that should modify tertiary paths is
circuit decommissions.