### PR TITLE
Ensuring Units remain in sync with the selected VLAN of an Endpoint

### DIFF
--- a/frontend/webservice/circuit.cgi
+++ b/frontend/webservice/circuit.cgi
@@ -673,13 +673,13 @@ sub update {
         }
     }
 
+    _send_remove_command($circuit->circuit_id);
+
     # Put rollback in place for quick tests
     # $db->rollback;
     $db->commit;
-
     warn Dumper($circuit->to_hash);
 
-    _send_remove_command($circuit->circuit_id);
     _send_update_cache($circuit->circuit_id);
     _send_add_command($circuit->circuit_id);
 


### PR DESCRIPTION
Ensures that if an Endpoint's VLAN changes its Junos Unit is updated
to match. There's no real reason for this except to assist network
engineers quickly identify interfaces associated with a connection. It
would be easier if the Unit could remain the same after initial
provisioning, regardless of any changes to the selected VLAN, but
Junos provides no way of locating units by other fields (like VLAN).