### PR TITLE
L2 and L3 Azure Connections

### DIFF
--- a/frontend/webservice/vrf.cgi
+++ b/frontend/webservice/vrf.cgi
@@ -13,7 +13,6 @@ use GRNOC::WebService::Dispatcher;
 
 use OESS::RabbitMQ::Client;
 use OESS::Cloud;
-use OESS::Cloud::AWS;
 use OESS::Config;
 use OESS::DB;
 use OESS::DB::Entity;

--- a/frontend/webservice/vrf.cgi
+++ b/frontend/webservice/vrf.cgi
@@ -332,12 +332,12 @@ sub provision_vrf{
                     cloud_account_id => $ep->{cloud_account_id}
                 );
             }
-
             if (!defined $interface) {
                 $method->set_error("Cannot find a valid Interface for $ep->{entity}.");
                 $db->rollback;
                 return;
             }
+
             my $valid_bandwidth = $interface->is_bandwidth_valid(bandwidth => $ep->{bandwidth});
             if (!$valid_bandwidth) {
                 $method->set_error("Couldn't create VRF: Specified bandwidth is invalid for $ep->{entity}.");
@@ -379,109 +379,42 @@ sub provision_vrf{
             $vrf->add_endpoint($endpoint);
             push @$add_endpoints, $endpoint;
 
-            if ($interface->cloud_interconnect_type eq 'azure-express-route') {
-                my $interface2 = $entity->select_interface(
-                    inner_tag    => $endpoint->{inner_tag},
-                    tag          => $endpoint->{tag},
-                    workgroup_id => $model->{workgroup_id},
-                    cloud_account_id => $ep->{cloud_account_id}
-                );
-                if (!defined $interface2) {
-                    $method->set_error("Cannot find a valid Interface for $endpoint->{entity}.");
-                    $db->rollback;
-                    return;
-                }
-                my $valid_bandwidth = $interface2->is_bandwidth_valid(bandwidth => $ep->{bandwidth});
-                if (!$valid_bandwidth) {
-                    $method->set_error("Couldn't create VRF: Specified bandwidth is invalid for $ep->{entity}.");
-                    $db->rollback;
-                    return;
-                }
-
-                # Populate Endpoint modal with selected Interface details.
-                $ep->{type}         = 'vrf';
-                $ep->{entity_id}    = $entity->{entity_id};
-                $ep->{interface}    = $interface2->{name};
-                $ep->{interface_id} = $interface2->{interface_id};
-                $ep->{node}         = $interface2->{node}->{name};
-                $ep->{node_id}      = $interface2->{node}->{node_id};
-                $ep->{cloud_interconnect_id}   = $interface2->cloud_interconnect_id;
-                $ep->{cloud_interconnect_type} = $interface2->cloud_interconnect_type;
-
-                my $endpoint2 = new OESS::Endpoint(db => $db, model => $ep);
-                my ($ep2_id, $ep2_err) = $endpoint2->create(
-                    vrf_id => $vrf->vrf_id,
-                    workgroup_id => $model->{workgroup_id}
-                );
-                if (defined $ep2_err) {
-                    $method->set_error("Couldn't create VRF: $ep2_err");
-                    $db->rollback;
-                    return;
-                }
-                $vrf->add_endpoint($endpoint2);
-                push @$add_endpoints, $endpoint2;
-
-                # pri_prefix: '192.168.100.248/30';
-                my $pri = new OESS::Peer(
-                    db => $db,
-                    model => {
-                        peer_asn => 12076,
-                        md5_key => '',
-                        local_ip => '192.168.100.249/30',
-                        peer_ip  => '192.168.100.250/30',
-                        version  => 4
-                    }
-                );
-                # sec_prefix: '192.168.100.252/30';
-                my $sec = new OESS::Peer(
-                    db => $db,
-                    model => {
-                        peer_asn => 12076,
-                        md5_key => '',
-                        local_ip => '192.168.100.253/30',
-                        peer_ip  => '192.168.100.254/30',
-                        version  => 4
-                    }
-                );
-                if ($endpoint->cloud_interconnect_id =~ /PRI/) {
-                    my ($peer_id, $peer_err) = $pri->create(vrf_ep_id => $endpoint->vrf_endpoint_id);
-                    if (defined $peer_err) {
-                        $method->set_error($peer_err);
-                        $db->rollback;
-                        return;
-                    }
-                    $endpoint->add_peer($pri);
-
-                    my ($peer2_id, $peer2_err) = $sec->create(vrf_ep_id => $endpoint2->vrf_endpoint_id);
-                    if (defined $peer2_err) {
-                        $method->set_error($peer2_err);
-                        $db->rollback;
-                        return;
-                    }
-                    $endpoint2->add_peer($sec);
-                }
-                else {
-                    my ($peer_id, $peer_err) = $sec->create(vrf_ep_id => $endpoint->vrf_endpoint_id);
-                    if (defined $peer_err) {
-                        $method->set_error($peer_err);
-                        $db->rollback;
-                        return;
-                    }
-                    $endpoint->add_peer($sec);
-
-                    my ($peer2_id, $peer2_err) = $pri->create(vrf_ep_id => $endpoint2->vrf_endpoint_id);
-                    if (defined $peer2_err) {
-                        $method->set_error($peer2_err);
-                        $db->rollback;
-                        return;
-                    }
-                    $endpoint2->add_peer($pri);
-                }
-            }
-
             foreach my $peering (@{$ep->{peers}}) {
                 if ($interface->cloud_interconnect_type eq 'azure-express-route') {
-                    # Peering configured when endpoints created above.
+                    my $peer;
+                    if ($endpoint->cloud_interconnect_id =~ /PRI/) {
+                        # pri_prefix: '192.168.100.248/30';
+                        $peer = new OESS::Peer(
+                            db => $db,
+                            model => {
+                                peer_asn => 12076,
+                                md5_key => '',
+                                local_ip => '192.168.100.249/30',
+                                peer_ip  => '192.168.100.250/30',
+                                version  => 4
+                            }
+                        );
+                    } else {
+                        # sec_prefix: '192.168.100.252/30';
+                        $peer = new OESS::Peer(
+                            db => $db,
+                            model => {
+                                peer_asn => 12076,
+                                md5_key => '',
+                                local_ip => '192.168.100.253/30',
+                                peer_ip  => '192.168.100.254/30',
+                                version  => 4
+                            }
+                        );
+                    }
+
+                    my ($peer_id, $peer_err) = $peer->create(vrf_ep_id => $endpoint->vrf_endpoint_id);
+                    if (defined $peer_err) {
+                        $method->set_error($peer_err);
+                        $db->rollback;
+                        return;
+                    }
+                    $endpoint->add_peer($peer);
                     next;
                 }
 

--- a/frontend/www/html_templates/l2/endpoint_selection_modal2.html
+++ b/frontend/www/html_templates/l2/endpoint_selection_modal2.html
@@ -34,7 +34,12 @@
                   </div>
                   <div class="form-group">
                     <label class="control-label">VLAN</label>
-                    <select class="form-control entity-vlans"></select>
+                    <div style="display: flex; align-items: center;">
+                      <select class="form-control entity-vlans"></select>
+                      <a class="entity-vlans-help" tabindex="0" class="btn btn-link" role="button" style="padding: 6px; margin: 0 0 0 6px;" data-toggle="popover" data-trigger="focus" data-container="body" data-html="true" data-content="">
+                        <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                      </a>
+                    </div>
                   </div>
                   <div class="form-group">
                     <label class="control-label">Max Bandwidth (Mb/s)</label>

--- a/frontend/www/js_templates/l2/endpoint_selection_modal.js
+++ b/frontend/www/js_templates/l2/endpoint_selection_modal.js
@@ -392,7 +392,7 @@ class EndpointSelectionModal2 {
         cloudAccountLabel.innerText = 'ExpressRoute Service Key';
         cloudAccountInput.setAttribute('placeholder', '00000000-0000-0000-0000-000000000000');
 
-        vlanHelp.dataset.content = '<b>Layer 2:</b> The sTag of a QnQ Tagged Interface connecting to Microsoft Azure. The selected sTag will be replaced by Microsoft. The cTag is selected by the user within the Azure Portal.<br/><b>Layer 3:</b> ...';
+        vlanHelp.dataset.content = '<b>Layer 2:</b> The sTag of a QnQ Tagged Interface connecting to Microsoft Azure; This will be modified by Microsoft while provisioning. The cTag is selected by the user within the Azure Portal.<br/><b>Layer 3:</b> The cTag of a QnQ Tagged Interface connecting to Microsoft Azure. The sTag is selected by Microsoft while provisioning.';
       } else {
         cloudAccountLabel.innerText = 'AWS Account Owner';
         cloudAccountInput.setAttribute('placeholder', '012301230123');

--- a/frontend/www/js_templates/l2/endpoint_selection_modal.js
+++ b/frontend/www/js_templates/l2/endpoint_selection_modal.js
@@ -391,14 +391,13 @@ class EndpointSelectionModal2 {
       } else if (entity.cloud_interconnect_type === 'azure-express-route') {
         cloudAccountLabel.innerText = 'ExpressRoute Service Key';
         cloudAccountInput.setAttribute('placeholder', '00000000-0000-0000-0000-000000000000');
-
-        vlanHelp.dataset.content = '<b>Layer 2:</b> The sTag of a QnQ Tagged Interface connecting to Microsoft Azure; This will be modified by Microsoft while provisioning. The cTag is selected by the user within the Azure Portal.<br/><b>Layer 3:</b> The cTag of a QnQ Tagged Interface connecting to Microsoft Azure. The sTag is selected by Microsoft while provisioning.';
+        vlanHelp.dataset.content = 'cTag of the QnQ Tagged Interface connecting to Microsoft Azure; This must match the peering VLAN selected within the Azure Portal when provisioning a Layer 2 Connection. The sTag is selected by Microsoft cannot be modified.';
       } else {
         cloudAccountLabel.innerText = 'AWS Account Owner';
         cloudAccountInput.setAttribute('placeholder', '012301230123');
       }
     } else {
-      vlanHelp.dataset.content = 'So say we all!';
+      vlanHelp.dataset.content = "Ethernet frame header of the Tagged Interface connecting to the selected Network Entity.";
     }
 
     // Max Bandwidth

--- a/frontend/www/js_templates/l2/endpoint_selection_modal.js
+++ b/frontend/www/js_templates/l2/endpoint_selection_modal.js
@@ -391,7 +391,7 @@ class EndpointSelectionModal2 {
       } else if (entity.cloud_interconnect_type === 'azure-express-route') {
         cloudAccountLabel.innerText = 'ExpressRoute Service Key';
         cloudAccountInput.setAttribute('placeholder', '00000000-0000-0000-0000-000000000000');
-        vlanHelp.dataset.content = 'cTag of the QnQ Tagged Interface connecting to Microsoft Azure; This must match the peering VLAN selected within the Azure Portal when provisioning a Layer 2 Connection. The sTag is selected by Microsoft cannot be modified.';
+        vlanHelp.dataset.content = '<b>Layer 2</b>: sTag of the QinQ Tagged Interface connecting to Microsoft Azure; This value will be overridden by Microsoft after provisioning.<br/><b>Layer 3</b>: cTag of the QinQ Tagged Interface connecting to Microsoft Azure. The sTag is selected by Microsoft and cannot be specified.';
       } else {
         cloudAccountLabel.innerText = 'AWS Account Owner';
         cloudAccountInput.setAttribute('placeholder', '012301230123');

--- a/frontend/www/js_templates/l2/endpoint_selection_modal.js
+++ b/frontend/www/js_templates/l2/endpoint_selection_modal.js
@@ -377,6 +377,7 @@ class EndpointSelectionModal2 {
     let cloudAccountFormGroup = this.parent.querySelector('.entity-cloud-account');
     let cloudAccountLabel = this.parent.querySelector('.entity-cloud-account-label');
     let cloudAccountInput = this.parent.querySelector('.entity-cloud-account-id');
+    let vlanHelp = this.parent.querySelector('.entity-vlans-help');
 
     cloudAccountFormGroup.style.display = 'none';
     cloudAccountInput.value = null;
@@ -390,10 +391,14 @@ class EndpointSelectionModal2 {
       } else if (entity.cloud_interconnect_type === 'azure-express-route') {
         cloudAccountLabel.innerText = 'ExpressRoute Service Key';
         cloudAccountInput.setAttribute('placeholder', '00000000-0000-0000-0000-000000000000');
+
+        vlanHelp.dataset.content = '<b>Layer 2:</b> The sTag of a QnQ Tagged Interface connecting to Microsoft Azure. The selected sTag will be replaced by Microsoft. The cTag is selected by the user within the Azure Portal.<br/><b>Layer 3:</b> ...';
       } else {
         cloudAccountLabel.innerText = 'AWS Account Owner';
         cloudAccountInput.setAttribute('placeholder', '012301230123');
       }
+    } else {
+      vlanHelp.dataset.content = 'So say we all!';
     }
 
     // Max Bandwidth

--- a/frontend/www/js_templates/modify_cloud.js
+++ b/frontend/www/js_templates/modify_cloud.js
@@ -162,6 +162,10 @@ class GlobalState extends Component {
   }
 }
 
+$(function () {
+  $('[data-toggle="popover"]').popover();
+});
+
 let state = new GlobalState();
 let modal = new EndpointSelectionModal2('#endpoint-selection-modal');
 

--- a/frontend/www/js_templates/modify_l2vpn.js
+++ b/frontend/www/js_templates/modify_l2vpn.js
@@ -98,6 +98,10 @@ class GlobalState extends Component {
   }
 }
 
+$(function () {
+  $('[data-toggle="popover"]').popover();
+});
+
 let state = new GlobalState();
 
 let modal = new EndpointSelectionModal2('#add-endpoint-modal');

--- a/frontend/www/js_templates/provision_cloud.js
+++ b/frontend/www/js_templates/provision_cloud.js
@@ -74,6 +74,9 @@ class GlobalState extends Component {
   }
 }
 
+$(function () {
+  $('[data-toggle="popover"]').popover();
+});
 
 let state = new GlobalState();
 

--- a/frontend/www/js_templates/provision_l2vpn.js
+++ b/frontend/www/js_templates/provision_l2vpn.js
@@ -64,6 +64,10 @@ class GlobalState extends Component {
   }
 }
 
+$(function () {
+  $('[data-toggle="popover"]').popover();
+});
+
 let state = new GlobalState();
 
 let schedule = new Schedule('#l2vpn-schedule-picker');

--- a/perl-lib/OESS/lib/OESS/Cloud.pm
+++ b/perl-lib/OESS/lib/OESS/Cloud.pm
@@ -65,7 +65,7 @@ sub setup_endpoints {
             my $aws = OESS::Cloud::AWS->new();
 
             my $amazon_addr   = undef;
-            my $asn           = 55038;
+            my $asn           = $config->local_as;
             my $auth_key      = undef;
             my $customer_addr = undef;
             my $ip_version    = 'ipv6';
@@ -152,7 +152,7 @@ sub setup_endpoints {
             if (defined $ep->vrf_endpoint_id) {
                 $peering = {
                     vlan             => $ep->tag,
-                    local_asn        => 55038,
+                    local_asn        => $config->local_as,
                     primary_prefix   => '192.168.100.248/30',
                     secondary_prefix => '192.168.100.252/30'
                 };

--- a/perl-lib/OESS/lib/OESS/Cloud.pm
+++ b/perl-lib/OESS/lib/OESS/Cloud.pm
@@ -145,6 +145,18 @@ sub setup_endpoints {
 
             my $azure = OESS::Cloud::Azure->new();
 
+            # Configure peering information only on layer 3
+            # connections.
+            my $peering;
+            if (defined $ep->vrf_endpoint_id) {
+                $peering = {
+                    vlan             => $ep->tag,
+                    local_asn        => 55038,
+                    primary_prefix   => '192.168.100.248/30',
+                    secondary_prefix => '192.168.100.252/30'
+                };
+            }
+
             my $conn = $azure->expressRouteCrossConnection($ep->cloud_interconnect_id, $ep->cloud_account_id);
             my $res = $azure->set_cross_connection_state_to_provisioned(
                 interconnect_id  => $ep->cloud_interconnect_id,
@@ -153,10 +165,7 @@ sub setup_endpoints {
                 region           => $conn->{location},
                 peering_location => $conn->{properties}->{peeringLocation},
                 bandwidth        => $conn->{properties}->{bandwidthInMbps},
-                vlan             => $ep->tag,
-                local_asn        => 55038,
-                primary_prefix   => '192.168.100.248/30',
-                secondary_prefix => '192.168.100.252/30'
+                peering          => $peering
             );
 
             $ep->cloud_connection_id($res->{id});

--- a/perl-lib/OESS/lib/OESS/Config.pm
+++ b/perl-lib/OESS/lib/OESS/Config.pm
@@ -227,4 +227,12 @@ sub base_url {
     return $self->{'config'}->{'base_url'};
 }
 
+=head2 local_as
+
+=cut
+sub local_as {
+    my $self = shift;
+    return $self->{'config'}->{'local_as'};
+}
+
 1;

--- a/perl-lib/OESS/lib/OESS/Config.pm
+++ b/perl-lib/OESS/lib/OESS/Config.pm
@@ -227,12 +227,4 @@ sub base_url {
     return $self->{'config'}->{'base_url'};
 }
 
-=head2 local_as
-
-=cut
-sub local_as {
-    my $self = shift;
-    return $self->{'config'}->{'local_as'};
-}
-
 1;

--- a/perl-lib/OESS/lib/OESS/DB/Endpoint.pm
+++ b/perl-lib/OESS/lib/OESS/DB/Endpoint.pm
@@ -101,6 +101,10 @@ sub fetch_all {
         push @$params, 'node.node_id=?';
         push @$values, $args->{node_id};
     }
+    if (defined $args->{cloud_account_id}) {
+        push @$params, 'cloud.cloud_account_id=?';
+        push @$values, $args->{cloud_account_id};
+    }
 
     my $where = (@$params > 0) ? 'WHERE ' . join(' AND ', @$params) : 'WHERE 1 ';
 
@@ -325,7 +329,7 @@ sub update_cloud {
     }
 
     my $cloud_connection_vrf_ep_id = -1;
-    if (defined $args->{endpoint}->{cloud_account_id} && defined $args->{endpoint}->{cloud_connection_id}) {
+    if (defined $args->{endpoint}->{cloud_account_id}) {
         my $iq = "
             insert into cloud_connection_vrf_ep
             (vrf_ep_id, circuit_ep_id, cloud_account_id, cloud_connection_id)
@@ -335,7 +339,7 @@ sub update_cloud {
             $args->{endpoint}->{vrf_endpoint_id},
             $args->{endpoint}->{circuit_ep_id},
             $args->{endpoint}->{cloud_account_id},
-            $args->{endpoint}->{cloud_connection_id}
+            $args->{endpoint}->{cloud_connection_id} || ''
         ]);
         if (!defined $cloud_connection_vrf_ep_id) {
             return (undef, $args->{db}->get_error);

--- a/perl-lib/OESS/lib/OESS/DB/Endpoint.pm
+++ b/perl-lib/OESS/lib/OESS/DB/Endpoint.pm
@@ -217,6 +217,7 @@ sub fetch_all {
             $where
             AND (vrf_ep.tag >= interface_acl.vlan_start)
             AND (vrf_ep.tag <= interface_acl.vlan_end)
+            AND vrf_ep.state != 'decom'
             ORDER BY interface_acl.eval_position ASC
         ";
 

--- a/perl-lib/OESS/lib/OESS/Endpoint.pm
+++ b/perl-lib/OESS/lib/OESS/Endpoint.pm
@@ -928,6 +928,15 @@ sub create {
         $self->{circuit_ep_id} = $circuit_ep_id;
         $self->{circuit_id} = $args->{circuit_id};
         $self->{unit} = $unit;
+
+        my ($cloud_conn_ep_id, $err) = OESS::DB::Endpoint::update_cloud(
+            db => $self->{db},
+            endpoint => $self->to_hash
+        );
+        if (defined $err) {
+            $self->{'logger'}->error("Couldn't create Endpoint: $err");
+            return (undef, "Couldn't create Endpoint: $err");
+        }
         return ($circuit_ep_id, undef);
 
     } elsif (defined $args->{vrf_id}) {
@@ -947,13 +956,21 @@ sub create {
         $self->{vrf_endpoint_id} = $vrf_ep_id;
         $self->{vrf_id} = $args->{vrf_id};
         $self->{unit} = $unit;
+
+        my ($cloud_conn_ep_id, $err) = OESS::DB::Endpoint::update_cloud(
+            db => $self->{db},
+            endpoint => $self->to_hash
+        );
+        if (defined $err) {
+            $self->{'logger'}->error("Couldn't create Endpoint: $err");
+            return (undef, "Couldn't create Endpoint: $err");
+        }
         return ($vrf_ep_id, undef);
 
     } else {
         $self->{'logger'}->error("Couldn't create Endpoint: No associated Circuit or VRF identifier specified.");
         return (undef, "Couldn't create Endpoint: No associated Circuit or VRF identifier specified.");
     }
-
 }
 
 =head2 remove

--- a/perl-lib/OESS/lib/OESS/Entity.pm
+++ b/perl-lib/OESS/lib/OESS/Entity.pm
@@ -250,6 +250,7 @@ sub select_interface {
             return undef;
         }
         $cloud_account_ep_count = scalar @$eps;
+        warn "$cloud_account_ep_count Endpoints used with this cloud_account_id";
     }
 
     foreach my $intf (@{$self->{interfaces}}) {
@@ -271,6 +272,7 @@ sub select_interface {
 
         if (defined $intf->cloud_interconnect_type && $intf->cloud_interconnect_type eq 'azure-express-route') {
             if (!defined $args->{cloud_account_id}) {
+                warn 'Azure Service key was not provided.';
                 return undef;
             }
 

--- a/perl-lib/OESS/lib/OESS/Entity.pm
+++ b/perl-lib/OESS/lib/OESS/Entity.pm
@@ -237,19 +237,23 @@ sub select_interface {
         @_
     };
 
+    if (!defined $self->{db}) {
+        $self->{logger}->warn('Interface selection may not return accurate results as database object not defined.');
+    }
+
     # Get number of Endpoints using the provided azure service key.
     # If cloud_account_id is already in use on another endpoint we'll
     # want to select the interface associated with the secondary azure
     # port. If the cloud_account_id is already in use on both the
     # primary and secondary the service key may no longer be used.
     my $cloud_account_ep_count = 0;
-    if (defined $args->{cloud_account_id}) {
+    if (defined $args->{cloud_account_id} && defined $self->{db}) {
         my ($eps, $eps_err) = OESS::DB::Endpoint::fetch_all(db => $self->{db}, cloud_account_id => $args->{cloud_account_id});
         if (defined $eps_err) {
             $self->{logger}->error($eps_err);
             return undef;
         }
-        $cloud_account_ep_count = scalar @$eps;
+        $cloud_account_ep_count = (defined $eps) ? scalar @$eps : 0;
         warn "$cloud_account_ep_count Endpoints used with this cloud_account_id";
     }
 

--- a/perl-lib/OESS/lib/OESS/Entity.pm
+++ b/perl-lib/OESS/lib/OESS/Entity.pm
@@ -7,6 +7,7 @@ package OESS::Entity;
 
 use Log::Log4perl;
 
+use OESS::DB::Endpoint;
 use OESS::DB::Entity;
 use OESS::User;
 
@@ -229,14 +230,27 @@ sub to_hash{
 sub select_interface {
     my $self = shift;
     my $args = {
-        inner_tag               => undef,
-        tag                     => undef,
-        workgroup_id            => undef,
+        inner_tag        => undef,
+        tag              => undef,
+        workgroup_id     => undef,
         cloud_account_id => undef,
-        # cloud_interconnect_id   => undef,
-        # cloud_interconnect_type => undef,
         @_
     };
+
+    # Get number of Endpoints using the provided azure service key.
+    # If cloud_account_id is already in use on another endpoint we'll
+    # want to select the interface associated with the secondary azure
+    # port. If the cloud_account_id is already in use on both the
+    # primary and secondary the service key may no longer be used.
+    my $cloud_account_ep_count = 0;
+    if (defined $args->{cloud_account_id}) {
+        my ($eps, $eps_err) = OESS::DB::Endpoint::fetch_all(db => $self->{db}, cloud_account_id => $args->{cloud_account_id});
+        if (defined $eps_err) {
+            $self->{logger}->error($eps_err);
+            return undef;
+        }
+        $cloud_account_ep_count = scalar @$eps;
+    }
 
     foreach my $intf (@{$self->{interfaces}}) {
         if (defined $intf->cloud_interconnect_type && $intf->cloud_interconnect_type eq 'gcp-partner-interconnect') {
@@ -255,12 +269,30 @@ sub select_interface {
             }
         }
 
+        if (defined $intf->cloud_interconnect_type && $intf->cloud_interconnect_type eq 'azure-express-route') {
+            if (!defined $args->{cloud_account_id}) {
+                return undef;
+            }
+
+            if ($intf->cloud_interconnect_id =~ /PRI/ && $cloud_account_ep_count == 0) {
+                # Only select if interface contains 'PRI'
+                warn 'Selecting primary Azure port.';
+            }
+            elsif ($intf->cloud_interconnect_id =~ /SEC/ && $cloud_account_ep_count == 1) {
+                # Only select if interface contains 'SEC'
+                warn 'Selecting secondary Azure port.';
+            }
+            else {
+                next;
+            }
+        }
+
         my $ok = $intf->vlan_valid(
             vlan => $args->{tag},
             workgroup_id => $args->{workgroup_id}
         );
         if ($ok) {
-            # TODO register and selected vlans as being in use so that
+            # Register selected vlans as being in use so that
             # successive calls to the same entity with the same vlan
             # yield different interfaces.
 

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -302,7 +302,7 @@ sub get_system_information{
 
     my $system_info = $self->{'jnx'}->get_dom();
     my $root_ns     = $system_info->documentElement()->namespaceURI();
-    $self->{logger}->info("Using root XML namespace $root_ns.");
+    $self->{logger}->debug("Using root XML namespace $root_ns.");
 
     my $xp = XML::LibXML::XPathContext->new($system_info);
     $xp->registerNs('x', $root_ns);
@@ -310,7 +310,7 @@ sub get_system_information{
     # Eg. http://xml.juniper.net/junos/15.1I0/junos
     my $junos_ns = $xp->lookupNs('junos');
     $self->{'root_namespace'} = substr($junos_ns, 0, -5);
-    $self->{logger}->info("Using JUNOS XML namespace $self->{'root_namespace'}.");
+    $self->{logger}->debug("Using JUNOS XML namespace $self->{'root_namespace'}.");
 
     my $host_name = $xp->findvalue('/x:rpc-reply/x:system-information/x:host-name');
     my $model =     $xp->findvalue('/x:rpc-reply/x:system-information/x:hardware-model');

--- a/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
@@ -97,10 +97,10 @@ sub new{
     #try and connect up right away
     my $ok = $self->{'device'}->connect();
     if (!$ok) {
-	warn "Unable to connect\n";
-	$self->{'logger'}->error("Connection to device could not be established.");
+        warn "Unable to connect\n";
+        $self->{'logger'}->error("Connection to device could not be established.");
     } else {
-	$self->{'logger'}->error("Connection to device was established.");
+        $self->{'logger'}->debug("Connection to device was established.");
     }
 
     $self->{'ckts'} = {};


### PR DESCRIPTION
Provisioning with Azure ExpressRoute has been modified to require selecting an endpoint for each Azure interconnect you wish to use; To peer with both primary and secondary interconnects on the same Connection you must select two Endpoints. The first Endpoint used with a service key will be provisioned to the primary interconnect and second Endpoint to the secondary interconnect. Port selection is based on a per-service key basis, which means that the primary and secondary interconnects may exist on separate Connections.