### PR TITLE
Fixing case where active links couldn't be made 'available'

### DIFF
--- a/perl-lib/OESS/lib/OESS/DB.pm
+++ b/perl-lib/OESS/lib/OESS/DB.pm
@@ -141,10 +141,21 @@ sub execute_query{
 
 =head2 start_transaction
 
+    my $error = $db->start_transaction;
+    die $error if defined $error;
+
 =cut
 sub start_transaction{
     my $self = shift;
-    $self->{'dbh'}->begin_work() or $self->{'logger'}->error("Error: " . $self->{'dbh'}->errstr);
+
+    my $ok = $self->{dbh}->begin_work;
+    return if $ok;
+
+    my $error = $self->{dbh}->errstr;
+    # Logging statement left for legacy cases.
+    $self->{logger}->error("Error: $error");
+
+    return $error;
 }
 
 =head2 commit

--- a/perl-lib/OESS/lib/OESS/Link.pm
+++ b/perl-lib/OESS/lib/OESS/Link.pm
@@ -30,6 +30,7 @@ use OESS::DB::Link;
             name           => 'node-a-to-node-b',
             remote_urn     => undef,
             status         => 'up',
+            link_state     => 'available',
             metric         => 1,
             interface_a_id => 1,
             ip_a           => '192.168.1.2',
@@ -95,6 +96,7 @@ sub from_hash {
     $self->{name} = $hash->{name};
     $self->{remote_urn} = $hash->{remote_urn};
     $self->{status} = $hash->{status};
+    $self->{link_state} = $hash->{link_state};
     $self->{metric} = $hash->{metric};
     $self->{node_a_id} = $hash->{node_a_id};
     $self->{node_a_loopback} = $hash->{node_a_loopback};
@@ -118,6 +120,7 @@ sub to_hash {
         name => $self->name,
         remote_urn => $self->remote_urn,
         status => $self->status,
+        link_state => $self->link_state,
         metric => $self->metric,
         node_a_id => $self->node_a_id,
         node_a_loopback => $self->node_a_loopback,
@@ -173,6 +176,18 @@ sub status {
         $self->{status} = $status;
     }
     return $self->{status};
+}
+
+=head2 link_state
+
+=cut
+sub link_state {
+    my $self = shift;
+    my $link_state = shift;
+    if (defined $link_state) {
+        $self->{link_state} = $link_state;
+    }
+    return $self->{link_state};
 }
 
 =head2 metric

--- a/perl-lib/OESS/t/z-DB/Link.t
+++ b/perl-lib/OESS/t/z-DB/Link.t
@@ -46,6 +46,7 @@ my ($ok, $update_err) = OESS::DB::Link::update(
     db => $db,
     link => {
         link_id => 1,
+        link_state => 'active',
         name => 'Link lolz',
         ip_z => undef,
         metric => 666,


### PR DESCRIPTION
Due to multiple link_instantiation table entries being created within
the same second, links with active ports couldn't be set to the
'available' state. This is pretty much the same as decom'n the link,
but since the ports are still up we wish to allow re-approval if
desired. Fixes #1007