### PR TITLE
Handle failures of calls to Switch::get_system_info

### DIFF
--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -267,7 +267,7 @@ sub unlock {
 
 =head2 get_system_information
 
-    my $info = get_system_information();
+    my ($info, $err) = get_system_information();
 
 get_system_information returns an object containing information about
 the connected device.
@@ -287,17 +287,14 @@ B<Result>
 sub get_system_information{
     my $self = shift;
 
-    if(!$self->connected()){
-	$self->{'logger'}->error("Not currently connected to device");
-	return;
+    if (!$self->connected) {
+        return (undef, "Not currently connected to device");
     }
 
     my $reply = $self->{'jnx'}->get_system_information();
-
-    if ($self->{'jnx'}->has_error){
+    if ($self->{'jnx'}->has_error) {
         my $error = $self->{'jnx'}->get_first_error();
-        $self->{'logger'}->error("Error fetching system information: " . $error->{'error_message'});
-        return;
+        return (undef, "Error fetching system information: $error->{error_message}");
     }
 
     my $system_info = $self->{'jnx'}->get_dom();
@@ -325,8 +322,7 @@ sub get_system_information{
     if ($self->{'jnx'}->has_error) {
         my $error = $self->{'jnx'}->get_first_error();
         $self->set_error($error->{'error_message'});
-        $self->{'logger'}->error("Error fetching interface information: " . $error->{'error_message'});
-        return;
+        return (undef, "Error fetching interface information: $error->{error_message}");
     }
 
     my $interfaces = $self->{'jnx'}->get_dom();
@@ -385,13 +381,19 @@ sub get_system_information{
 		}
 	    }
 	}
-
-	
     }
 
     $self->{'loopback_addr'} = $loopback_addr;
     $self->{'major_rev'} = $major_rev;
-    return {model => $model, version => $version, os_name => $os_name, host_name => $host_name, loopback_addr => $loopback_addr};
+
+    my $result = {
+        host_name     => $host_name,
+        loopback_addr => $loopback_addr,
+        os_name       => $os_name,
+        model         => $model,
+        version       => $version,
+    };
+    return ($result, undef);
 }
 
 =head2 get_routed_lsps
@@ -1752,7 +1754,12 @@ sub verify_connection{
         return 0;
     }
 
-    my $sysinfo = $self->get_system_information();
+    my ($sysinfo, $err) = $self->get_system_information();
+    if (defined $err) {
+        $self->{'logger'}->error("Couldn't get system information: $err");
+        return 0;
+    }
+
     foreach my $fw (@{$self->{'supported_firmware'}}) {
         if ($sysinfo->{'os_name'} eq $fw->{'make'} && $sysinfo->{'model'} eq $fw->{'model'} && $sysinfo->{'version'} eq $fw->{'number'} && $sysinfo->{'major_rev'} eq $fw->{'major_rev'}) {
             return 1;

--- a/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Switch.pm
@@ -299,11 +299,12 @@ sub _register_rpc_methods{
                                             description => "returns the current connected state of the device");
     $dispatcher->register_method($method);
 
-    $method = GRNOC::RabbitMQ::Method->new( name        => "get_system_info",
-					    callback    => sub {
-						$self->get_system_info();
-					    },
-					    description => "returns the system information");
+    $method = GRNOC::RabbitMQ::Method->new(
+        name        => "get_system_info",
+        async       => 1,
+        callback    => sub { $self->get_system_info(@_); },
+        description => "returns the system information"
+    );
     $dispatcher->register_method($method);
 
     $method = GRNOC::RabbitMQ::Method->new( name        => "diff",
@@ -457,12 +458,20 @@ sub add_vlan{
 =head2 get_system_info
 
 =cut
-sub get_system_info{
+sub get_system_info {
     my $self = shift;
-    my $m_ref = shift;
-    my $p_ref = shift;
+    my $method = shift;
+    my $params = shift;
 
-    return $self->{'device'}->get_system_information();
+    my $success = $method->{'success_callback'};
+    my $error   = $method->{'error_callback'};
+
+    my ($info, $err) = $self->{'device'}->get_system_information();
+    if (defined $err) {
+        $self->{'logger'}->error($err);
+        return &$error($err);
+    }
+    return &$success($info);
 }
 
 

--- a/perl-lib/OESS/t/mpls/mx-get_system_information.t
+++ b/perl-lib/OESS/t/mpls/mx-get_system_information.t
@@ -221,7 +221,7 @@ $mock->new_sub(
 </rpc-reply>')
 );
 
-my $result = $device->get_system_information();
+my ($result, undef) = $device->get_system_information();
 
 my $err = $mock->sub_called(
 name  => 'get_system_information',


### PR DESCRIPTION
get_system_info previously returned undef on error. This caused the
result handler's error check to be bypassed and as a result cleared
the node's loopback address from the database. get_system_info was
modified to properly return an error on failure; The loopback should
now only be cleared if it's unable to be found on the device.
Fixes #829