### PR TITLE
Always passes selected Endpoint entity

### DIFF
--- a/frontend/www/js_templates/api/circuit.js
+++ b/frontend/www/js_templates/api/circuit.js
@@ -60,6 +60,7 @@ async function provisionCircuit(workgroupID, description, endpoints, start=-1, e
     } else {
       e['interface'] = endpoint.interface;
       e['node']      = endpoint.node;
+      e['entity']    = endpoint.entity;
     }
 
     form.append('endpoint', JSON.stringify(e));

--- a/frontend/www/js_templates/api/vrf.js
+++ b/frontend/www/js_templates/api/vrf.js
@@ -66,6 +66,7 @@ async function provisionVRF(workgroupID, name, description, endpoints, provision
     } else {
       e['interface'] = endpoint.interface;
       e['node']      = endpoint.node;
+      e['entity']    = endpoint.entity;
     }
 
     if (endpoint.peers.length < 1) {


### PR DESCRIPTION
Cloud connections require a properly selected entity. Prior to this
change selecting an interface under a Cloud entity resulted in the
Entity not being passed to the provisioning api. Fixes #1053