### PR TITLE
trim whitespace from cloud_account_ids

### DIFF
--- a/frontend/www/js_templates/l2/endpoint_selection_modal.js
+++ b/frontend/www/js_templates/l2/endpoint_selection_modal.js
@@ -504,7 +504,7 @@ class EndpointSelectionModal2 {
 
       endpoint.bandwidth = bandwidthSelector.options[bandwidthSelector.selectedIndex].value;
       endpoint.tag = vlanSelector.options[vlanSelector.selectedIndex].value;
-      endpoint.cloud_account_id = cloudAccountInput.value;
+      endpoint.cloud_account_id = (cloudAccountInput.value) ? cloudAccountInput.value.trim() : '';
       endpoint.entity = entity.name;
       endpoint.name = selectedInterface;
       endpoint.node = selectedNode;


### PR DESCRIPTION
Some cloud platforms provide their keys prefixed or postfixed with
spaces causing provisioning errors if not first stripped. Fixes #1047