### PR TITLE
allow interface selection on aws-hosted-connections

### DIFF
--- a/frontend/webservice/circuit.cgi
+++ b/frontend/webservice/circuit.cgi
@@ -275,12 +275,15 @@ sub provision {
         my $entity;
         my $interface;
 
-        if (defined $ep->{node} && defined $ep->{interface} && (!defined $ep->{cloud_account_id} || $ep->{cloud_account_id} eq '')) {
+        if (defined $ep->{node} && defined $ep->{interface}) {
             $interface = new OESS::Interface(
                 db => $db,
                 name => $ep->{interface},
                 node => $ep->{node}
             );
+        }
+        if (defined $interface && (!defined $interface->{cloud_interconnect_type} || $interface->{cloud_interconnect_type} eq 'aws-hosted-connection')) {
+            # Continue
         } else {
             $entity = new OESS::Entity(db => $db, name => $ep->{entity});
             $interface = $entity->select_interface(
@@ -486,12 +489,15 @@ sub update {
             my $entity;
             my $interface;
 
-            if (defined $ep->{node} && defined $ep->{interface} && (!defined $ep->{cloud_account_id} || $ep->{cloud_account_id} eq '')) {
+            if (defined $ep->{node} && defined $ep->{interface}) {
                 $interface = new OESS::Interface(
                     db => $db,
                     name => $ep->{interface},
                     node => $ep->{node}
                 );
+            }
+            if (defined $interface && (!defined $interface->{cloud_interconnect_type} || $interface->{cloud_interconnect_type} eq 'aws-hosted-connection')) {
+                # Continue
             } else {
                 $entity = new OESS::Entity(db => $db, name => $ep->{entity});
                 $interface = $entity->select_interface(
@@ -501,7 +507,6 @@ sub update {
                     cloud_account_id => $ep->{cloud_account_id}
                 );
             }
-
             if (!defined $interface) {
                 $method->set_error("Cannot find a valid Interface for $ep->{entity}.");
                 return;

--- a/frontend/webservice/vrf.cgi
+++ b/frontend/webservice/vrf.cgi
@@ -368,12 +368,15 @@ sub provision_vrf{
             my $entity;
             my $interface;
 
-            if (defined $ep->{node} && defined $ep->{interface} && (!defined $ep->{cloud_account_id} || $ep->{cloud_account_id} eq '')) {
+            if (defined $ep->{node} && defined $ep->{interface}) {
                 $interface = new OESS::Interface(
                     db => $db,
                     name => $ep->{interface},
                     node => $ep->{node}
                 );
+            }
+            if (defined $interface && (!defined $interface->{cloud_interconnect_type} || $interface->{cloud_interconnect_type} eq 'aws-hosted-connection')) {
+                # Continue
             } else {
                 $entity = new OESS::Entity(db => $db, name => $ep->{entity});
                 $interface = $entity->select_interface(

--- a/frontend/www/js_templates/l2/endpoint_selection_modal.js
+++ b/frontend/www/js_templates/l2/endpoint_selection_modal.js
@@ -309,7 +309,7 @@ class EndpointSelectionModal2 {
       let checked = 'checked';
       let disabled = '';
       let notAllow = '';
-      if (child.cloud_interconnect_type !== null && child.cloud_interconnect_type !== '') {
+      if (child.cloud_interconnect_type !== null && child.cloud_interconnect_type !== '' && child.cloud_interconnect_type !== 'aws-hosted-connection') {
         checked = '';
         disabled = 'disabled';
         notAllow = 'cursor: not-allowed;';


### PR DESCRIPTION
Ideally interface selection for aws-hosted-connections would be automatic based on the provisioned bandwidth, but for now allow manual selection.