### PR TITLE
fix case where layer3 conn not properly removed

### DIFF
--- a/frontend/webservice/vrf.cgi
+++ b/frontend/webservice/vrf.cgi
@@ -762,6 +762,9 @@ sub remove_vrf {
         $method->set_error("Unable to find VRF: " . $vrf_id);
         return {success => 0};
     }
+    $vrf->load_endpoints;
+    $vrf->load_workgroup;
+    $vrf->load_users;
 
     my $result;
     if(!$user->in_workgroup( $wg) && !$user->is_admin()){
@@ -777,10 +780,10 @@ sub remove_vrf {
         return;
     }
 
-    $vrf->decom(user_id => $user->user_id());
-
     my $res = vrf_del(method => $method, vrf_id => $vrf_id);
     $res->{'vrf_id'} = $vrf_id;
+
+    $vrf->decom(user_id => $user->user_id());
 
     # send the update cache to the MPLS fwdctl
     _update_cache(vrf_id => $vrf_id);


### PR DESCRIPTION
$vrf->decom was called prior to vrf_del which, due to FWDCTLs behavior
(load-from-db then write cache), resulted in the layer3 conn being in
the decom state prior to removal from switch; Since a decom'd layer3
conn can't be removed from the network the connection was never torn
down. We fix this by moving the $vrf->decom call after vrf_del.

We also call $vrf->load_endpoints to ensure that info required to
cleanup cloud connections is present on remove_vrf.