### PR TITLE
add reserved bandwidth to interface object

### DIFF
--- a/frontend/www/html_templates/l2/endpoint_selection_modal2.html
+++ b/frontend/www/html_templates/l2/endpoint_selection_modal2.html
@@ -27,7 +27,7 @@
                 <!-- entity form -->
                 <div class="form-group">
                   <input class="form-control entity-search" type="text" placeholder="Search"/>
-                  <div class="list-group entity-search-list" style="max-height:250px; overflow-y:scroll; position: absolute; width: 95%; z-index: 100; box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);"></div>
+                  <div class="list-group entity-search-list" style="display: none; max-height:250px; overflow-y:scroll; position: absolute; width: 95%; z-index: 100; box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);"></div>
 
                   <div style="height: 200px; overflow-y: scroll; margin-top: 15px; margin-bottom: 15px;">
                     <div class="list-group entity-list">Loading...</div>

--- a/frontend/www/js_templates/l2/endpoint_selection_modal.js
+++ b/frontend/www/js_templates/l2/endpoint_selection_modal.js
@@ -214,9 +214,10 @@ class EndpointSelectionModal2 {
     }
 
     this.parent.querySelector('.entity-search').oninput = function(search) {
+      let list = this.parent.querySelector('.entity-search-list');
       if (search.target.value.length < 2) {
-        let list = this.parent.querySelector('.entity-search-list');
         list.innerHTML = '';
+        list.style.display = 'none';
         return null;
       }
 
@@ -224,11 +225,10 @@ class EndpointSelectionModal2 {
       // search query was updated.
       clearTimeout(this.searchTimeout);
 
-      // TODO FIX THIS
       this.searchTimeout = setTimeout(function() {
         getEntitiesAll(session.data.workgroup_id, search.target.value).then(function(entities) {
-          let list = this.parent.querySelector('.entity-search-list');
           list.innerHTML = '';
+          list.style.display = 'block';
 
           for (let i = 0; i < entities.length; i++) {
             let l = document.createElement('a');
@@ -238,6 +238,7 @@ class EndpointSelectionModal2 {
             l.onclick = (e) => {
               search.target.value = '';
               list.innerHTML = '';
+              list.style.display = 'none';
 
               entities[i].index = index;
               this.populateEntityForm(entities[i]);
@@ -319,6 +320,10 @@ class EndpointSelectionModal2 {
         notAllow = 'cursor: not-allowed;';
       }
 
+      // TODO After interface speed is recorded in the database,
+      // update our bandwidth details to include available bandwidth.
+      // ex.
+      // <b>${child.node}</b> ${child.name} <br/><span>${child.utilized_bandwidth}Mb reserved / ${child.bandwidth}Mb available</span>
       let elem = document.createElement('li');
       elem.setAttribute('class', `list-group-item ${disabled}`);
       elem.innerHTML = `
@@ -331,7 +336,7 @@ class EndpointSelectionModal2 {
                    ${checked}
                    ${disabled}
             />
-            <b>${child.node}</b> ${child.name}
+            <b>${child.node}</b> ${child.name} <br/><span>${child.utilized_bandwidth}Mb reserved</span>
           </label>
         </div>`;
       elem.addEventListener('click', function(e) {

--- a/perl-lib/OESS/lib/OESS/Interface.pm
+++ b/perl-lib/OESS/lib/OESS/Interface.pm
@@ -68,7 +68,7 @@ sub from_hash{
     $self->{'used_vlans'} = $hash->{'used_vlans'};
     $self->{'operational_state'} = $hash->{'operational_state'};
     $self->{'workgroup_id'} = $hash->{'workgroup_id'};
-
+    $self->{'utilized_bandwidth'} = $hash->{'utilized_bandwidth'} || 0;
     return 1;
 }
 
@@ -92,7 +92,8 @@ sub to_hash{
                 node => $self->node()->name(),
                 acls => $acl_models,
                 operational_state => $self->{'operational_state'},
-                workgroup_id => $self->workgroup_id() };
+                workgroup_id => $self->workgroup_id(),
+                utilized_bandwidth => $self->{utilized_bandwidth} };
 
     return $res;
 }


### PR DESCRIPTION
This reserved bandwidth is displayed in the endpoint selection modal
under each interface within an entity. The entity autocomplete
dropdown is modified to display correctly on firefox and safari
browsers.