### PR TITLE
Interface speed discovery

### DIFF
--- a/frontend/www/js_templates/l2/endpoint_selection_modal.js
+++ b/frontend/www/js_templates/l2/endpoint_selection_modal.js
@@ -326,10 +326,6 @@ class EndpointSelectionModal2 {
         notAllow = 'cursor: not-allowed;';
       }
 
-      // TODO After interface speed is recorded in the database,
-      // update our bandwidth details to include available bandwidth.
-      // ex.
-      // <b>${child.node}</b> ${child.name} <br/><span>${child.utilized_bandwidth}Mb reserved / ${child.bandwidth}Mb available</span>
       let elem = document.createElement('li');
       elem.setAttribute('class', `list-group-item ${disabled}`);
       elem.innerHTML = `
@@ -342,7 +338,7 @@ class EndpointSelectionModal2 {
                    ${checked}
                    ${disabled}
             />
-            <b>${child.node}</b> ${child.name} <br/><span>${child.utilized_bandwidth}Mb reserved</span>
+            <b>${child.node}</b> ${child.name} <br/><span>${child.utilized_bandwidth}Mb reserved / ${child.bandwidth}Mb total</span>
           </label>
         </div>`;
       elem.addEventListener('click', function(e) {

--- a/perl-lib/OESS/lib/OESS/DB/Interface.pm
+++ b/perl-lib/OESS/lib/OESS/DB/Interface.pm
@@ -25,7 +25,13 @@ sub fetch{
 
     my $interface_id = $params{'interface_id'};
 
-    my $interface = $db->execute_query("select * from interface join interface_instantiation on interface.interface_id=interface_instantiation.interface_id and end_epoch=-1 where interface.interface_id = ?",[$interface_id]);
+    my $interface = $db->execute_query(
+        "select *, interface_instantiation.capacity_mbps as bandwidth, interface_instantiation.mtu_bytes as mtu
+         from interface
+         join interface_instantiation on interface.interface_id=interface_instantiation.interface_id and interface_instantiation.end_epoch=-1
+         where interface.interface_id=?",
+        [$interface_id]
+    );
 
     return if (!defined($interface) || !defined($interface->[0]));
 
@@ -79,9 +85,9 @@ sub fetch{
         workgroup_id => $interface->{'workgroup_id'},
         acls => $acls,
         used_vlans => $in_use,
-        bandwidth => $interface->{capacity_mbps},
+        bandwidth => $interface->{bandwidth},
         utilized_bandwidth => $l2_utilized_bandwidth + $l3_utilized_bandwidth,
-        mtu => $interface->{mtu_bytes},
+        mtu => $interface->{mtu},
         admin_state => $interface->{admin_state},
         node_id => $interface->{node_id}
     };

--- a/perl-lib/OESS/lib/OESS/Interface.pm
+++ b/perl-lib/OESS/lib/OESS/Interface.pm
@@ -69,6 +69,9 @@ sub from_hash{
     $self->{'operational_state'} = $hash->{'operational_state'};
     $self->{'workgroup_id'} = $hash->{'workgroup_id'};
     $self->{'utilized_bandwidth'} = $hash->{'utilized_bandwidth'} || 0;
+    $self->{'bandwidth'} = $hash->{'bandwidth'} || 0;
+    $self->{'mtu'} = $hash->{'mtu'} || 0;
+
     return 1;
 }
 
@@ -93,7 +96,9 @@ sub to_hash{
                 acls => $acl_models,
                 operational_state => $self->{'operational_state'},
                 workgroup_id => $self->workgroup_id(),
-                utilized_bandwidth => $self->{utilized_bandwidth} };
+                utilized_bandwidth => $self->{'utilized_bandwidth'},
+                bandwidth => $self->{'bandwidth'},
+                mtu => $self->{'mtu'} };
 
     return $res;
 }

--- a/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Device/Juniper/MX.pm
@@ -622,19 +622,6 @@ sub _process_interface{
     $obj->{'mtu'} = trim($xp->findvalue('./j:mtu'));
     $obj->{'addresses'} = [];
 
-    my $speed = trim($xp->findvalue('./j:speed'));
-    if ($speed =~ /mbps/) {
-        $speed =~ s/mbps//g;
-        $obj->{'speed'} = int($speed);
-    }
-    elsif ($speed =~ /Gbps/) {
-        $speed =~ s/Gbps//g;
-        $obj->{'speed'} = int($speed) * 1000;
-    }
-    else {
-        $obj->{'speed'} = undef;
-    }
-
     if (!defined $obj->{'description'} || $obj->{'description'} eq '') {
         $obj->{'description'} = $obj->{'name'};
     }

--- a/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
@@ -106,6 +106,26 @@ sub new{
     $self->{'db'} = OESS::Database->new(config => $config_filename);
     die if (!defined $self->{'db'});
 
+
+    $self->{'interface'} = OESS::MPLS::Discovery::Interface->new(
+        db => $self->{'db'},
+        lsp_processor => sub{ $self->lsp_handler(); }
+    );
+    die "Unable to create Interface processor\n" if !defined $self->{'interface'};
+
+    $self->{'lsp'} = OESS::MPLS::Discovery::LSP->new(db => $self->{'db'});
+    die "Unable to create LSP Processor\n" if !defined $self->{'lsp'};
+
+    $self->{'isis'} = OESS::MPLS::Discovery::ISIS->new(db => $self->{'db'});
+    die "Unable to create ISIS Processor\n" if !defined $self->{'isis'};
+
+    $self->{'path'} = OESS::MPLS::Discovery::Paths->new(
+        db => $self->{'db'},
+        config => $self->{config_filename}
+    );
+    die "Unable to create Path Processor\n" if !defined $self->{'path'};
+
+
     $self->{'interface'} = $self->_init_interfaces();
     die if (!defined $self->{'interface'});
 
@@ -285,66 +305,6 @@ sub run{
 
     $self->{'children'}->{$id} = {};
     $self->{'children'}->{$id}->{'rpc'} = 1;
-}
-
-=head2 _init_interfaces
-
-initialize our sub modules...
-
-=cut
-sub _init_interfaces{
-    my $self = shift;
-    
-    my $ints = OESS::MPLS::Discovery::Interface->new( db => $self->{'db'},
-						      lsp_processor => sub{ $self->lsp_handler(); } );
-    if(!defined($ints)){
-	die "Unable to create Interface processor\n";
-    }
-
-    return $ints;
-}
-
-=head2 _init_lsp
-
-=cut
-sub _init_lsp{
-    my $self = shift;
-
-    my $lsps = OESS::MPLS::Discovery::LSP->new( db => $self->{'db'} );
-    if(!defined($lsps)){
-	die "Unable to create LSP Processor\n";
-    }
-
-    return $lsps;
-
-}
-
-=head2 _init_isis
-
-=cut
-sub _init_isis{  
-    my $self = shift;
-
-    my $isis = OESS::MPLS::Discovery::ISIS->new( db => $self->{'db'} );
-    if(!defined($isis)){
-	die "Unable to create ISIS Processor\n";
-    }
-
-    return $isis;
-
-}
-
-=head2 _init_paths
-
-=cut
-sub _init_paths{
-    my $self = shift;
-    my $paths = OESS::MPLS::Discovery::Paths->new( db => $self->{'db'}, config => $self->{config_filename} );
-    if(!defined($paths)){
-        die "Unable to create Path Processor\n";
-    }
-
-    return $paths;
 }
 
 =head2 int_handler

--- a/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Discovery.pm
@@ -126,18 +126,6 @@ sub new{
     die "Unable to create Path Processor\n" if !defined $self->{'path'};
 
 
-    $self->{'interface'} = $self->_init_interfaces();
-    die if (!defined $self->{'interface'});
-
-    $self->{'lsp'} = $self->_init_lsp();
-    die if (!defined $self->{'lsp'});
-
-    $self->{'isis'} = $self->_init_isis();
-    die if (!defined $self->{'isis'});
-
-    $self->{'path'} = $self->_init_paths();
-    die if (!defined $self->{'path'});
-
     my $tsds_conf = $self->{'db'}->{'configuration'}->{'tsds'};
     $self->{'tsds_svc'} = GRNOC::WebService::Client->new(
         url => $tsds_conf->{'url'} . "/push.cgi",

--- a/perl-lib/OESS/lib/OESS/MPLS/Discovery/Interface.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Discovery/Interface.pm
@@ -6,6 +6,8 @@ use warnings;
 package OESS::MPLS::Discovery::Interface;
 
 use OESS::Database;
+
+use Data::Dumper;
 use Log::Log4perl;
 
 =head2 new
@@ -40,10 +42,9 @@ sub new{
 
 =head2 process_results
 
-    processes results and sends them to the db
+processes results and sends them to the db
 
 =cut
-
 sub process_results{
     my $self = shift;
     my %params = @_;
@@ -51,55 +52,55 @@ sub process_results{
     my $interfaces = $params{'interfaces'};
 
     $self->{'db'}->_start_transaction();
-    
+
     foreach my $interface (@$interfaces) {
+        my $interface_id = $self->{'db'}->get_interface_id_by_names(node => $node_name, interface => $interface->{'name'});
+        if (!defined($interface_id)) {
+            my $node = $self->{'db'}->get_node_by_name(name => $node_name);
+            if (!defined($node)) {
+                $self->{'logger'}->warn($self->{'db'}->{'error'});
+                $self->{'db'}->_rollback();
+                return;
+            }
 
-	my $interface_id = $self->{'db'}->get_interface_id_by_names(node => $node_name, interface => $interface->{'name'});
-	if (!defined($interface_id)) {
-	    my $node = $self->{'db'}->get_node_by_name(name => $node_name);
-	    if (!defined($node)) {
-		$self->{'logger'}->warn($self->{'db'}->{'error'});
-		$self->{'db'}->_rollback();
-		return;
-	    }
+            my $res = $self->{'db'}->add_or_update_interface(
+                node_id => $node->{'node_id'},
+                name => $interface->{'name'},
+                operational_state => $interface->{'operational_state'},
+                admin_state => $interface->{'admin_state'},
+                description => $interface->{'description'},
+                vlan_tag_range => "-1",
+                mpls_vlan_tag_range => "1-4095",
+                capacity_mbps => $interface->{'speed'},
+                mtu_bytes => $interface->{'mtu'}
+            );
+            if (!defined($res)) {
+                $self->{'logger'}->warn($self->{'db'}->{'error'});
+                $self->{'db'}->_rollback();
+                return;
+            } else {
+                next;
+            }
+        }
 
-        my $res = $self->{'db'}->add_or_update_interface(
-            node_id => $node->{'node_id'},
-            name => $interface->{'name'},
-            operational_state => $interface->{'operational_state'},
-            admin_state => $interface->{'admin_state'},
-            description => $interface->{'description'},
-            vlan_tag_range => "-1",
-            mpls_vlan_tag_range => "1-4095",
-            capacity_mbps => $interface->{'speed'}
-        );
-	    if (!defined($res)) {
-		$self->{'logger'}->warn($self->{'db'}->{'error'});
-		$self->{'db'}->_rollback();
-		return;
-	    } else {
-		next;
-	    }
-	}
+        my $intf = $self->{'db'}->get_interface(interface_id => $interface_id);
+        if (!defined($intf)) {
+            $self->{'logger'}->warn($self->{'db'}->{'error'});
+            $self->{'db'}->_rollback();
+            return;
+        }
 
-	my $intf = $self->{'db'}->get_interface(interface_id => $interface_id);
-	if (!defined($intf)) {
-	    $self->{'logger'}->warn($self->{'db'}->{'error'});
-	    $self->{'db'}->_rollback();
-	    return;
-	}
-
-	if ($intf->{'operational_state'} ne $interface->{'operational_state'}) {
-	    my $result = $self->{'db'}->update_interface_operational_state(
-		interface_id => $interface_id,
-		operational_state => $interface->{'operational_state'}
-		);
-	    if (!defined($result)) {
-		$self->{'logger'}->warn($self->{'db'}->{'error'});
-		$self->{'db'}->_rollback();
-		return;
-	    }
-	}
+        if ($intf->{'operational_state'} ne $interface->{'operational_state'}) {
+            my $result = $self->{'db'}->update_interface_operational_state(
+                interface_id => $interface_id,
+                operational_state => $interface->{'operational_state'}
+            );
+            if (!defined($result)) {
+                $self->{'logger'}->warn($self->{'db'}->{'error'});
+                $self->{'db'}->_rollback();
+                return;
+            }
+        }
     }
 
     # all must have worked, commit and return success

--- a/perl-lib/OESS/t/entity-02-logic.t
+++ b/perl-lib/OESS/t/entity-02-logic.t
@@ -112,7 +112,7 @@ cmp_deeply(
     'Entity 2: parents() returns info on correct parent entities'
 );
 
-
+warn Dumper($ent2->interfaces());
 
 my $ent3 = OESS::Entity->new( entity_id => 12, db => $db );
 

--- a/perl-lib/OESS/t/mpls/mx-get_interfaces.t
+++ b/perl-lib/OESS/t/mpls/mx-get_interfaces.t
@@ -248,6 +248,7 @@ my $ints = [{
     'description' => 'Management Interface',
     'admin_state' => 'up',
     'operational_state' => 'up',
+    'mtu' => 1514,
     'speed' => 1000
 }];
 


### PR DESCRIPTION
Saves the network interface speed and mtu collected during interface discovery. Displays interface speed alongside reserved bandwidth on the endpoint selection modal.

This pull request should be merged last.