### PR TITLE
1098 update azure poller

### DIFF
--- a/app/oess_pull_azure_interfaces.pl
+++ b/app/oess_pull_azure_interfaces.pl
@@ -16,6 +16,8 @@ use OESS::DB;
 use OESS::DB::Endpoint;
 use OESS::Endpoint;
 
+Log::Log4perl::init_and_watch('/etc/oess/logging.conf',10);
+
 my $logger;
 
 sub main{
@@ -31,10 +33,17 @@ sub main{
         cloud_interconnect_type => 'azure-express-route'
     );
 
+    
     foreach my $cloud (@azure_cloud_accounts_config) {
-        my $azure_connections = ($azure->expressRouteCrossConnections($cloud->{interconnect_id}));
-        reconcile_oess_endpoints($db, $endpoints, $azure_connections);
+        my $connectionsWithNoPeering = ($azure->expressRouteCrossConnections($cloud->{interconnect_id}));
+        my $azure_connections = [];
+        foreach my $conn (@$connectionsWithNoPeering) {
+            my $connWithPeering = $azure->expressRouteCrossConnection($cloud->{interconnect_id}, $conn->{name});
+            push($azure_connections, $connWithPeering);
+        }
+        reconcile_oess_endpoints($db, $endpoints, $azure_connections, $cloud->{interconnect_id});
     }
+
 }
 
 =head2 get_connection_by_id
@@ -65,6 +74,8 @@ sub reconcile_oess_endpoints {
     my $db = shift;
     my $endpoints = shift;
     my $azure_connections = shift;
+    my $cloud_interconnect_id = shift;
+    my $logger = Log::Log4perl->get_logger('OESS.Cloud.Azure.Syncer');
 
     foreach my $endpoint (@$endpoints) {
         my $azure_connection = get_connection_by_id(
@@ -73,12 +84,26 @@ sub reconcile_oess_endpoints {
         );
         next if (!defined $azure_connection);
 
+        my $ep = new OESS::Endpoint(db => $db, model => $endpoint);
+        $ep->load_peers();
+        next if(! $cloud_interconnect_id eq $ep->cloud_interconnect_id());
+
+        my $could_account_id = $azure_connection->{name};
+        my $azure_subnet = find_matching_azure_connection($azure_connection, $cloud_interconnect_id);
+        my $endpoint_peer = get_endpoint_peer($ep, $cloud_interconnect_id, $could_account_id);
+
+        next if(!defined $azure_subnet || !defined $endpoint_peer);
+        
+        if(!(increment_ip($endpoint_peer->{local_ip}, -1) eq $azure_subnet)){
+            $logger->info("MISMATCH: on could_account_id: $could_account_id cloud_interconnect_id: $cloud_interconnect_id azure_subnet: $azure_subnet but OESS is peering on $endpoint_peer->{local_ip}");
+            update_endpoint_peer_ips($db, $azure_subnet, $endpoint_peer);
+        }
+
         my $cloud_bandwidth = $azure_connection->{properties}->{bandwidthInMbps};
         if (!$cloud_bandwidth || $endpoint->{bandwidth} eq $cloud_bandwidth) {
             next;
         }
 
-        my $ep = new OESS::Endpoint(db => $db, model => $endpoint);
         $ep->bandwidth($cloud_bandwidth);
 
         my $error = $ep->update_db;
@@ -86,6 +111,70 @@ sub reconcile_oess_endpoints {
             warn $error;
         }
     }
+}
+
+sub find_matching_azure_connection{
+    my $azure_connection_info = shift;
+    my $cloud_interconnect_id = shift;
+    my $azure_peering_subnet;
+    my $peering = $azure_connection_info->{properties}->{peerings};
+    foreach my $ip (@$peering){
+        if($cloud_interconnect_id =~ m/-SEC-/){
+            $azure_peering_subnet = $ip->{properties}->{secondaryPeerAddresssubnet};
+        }elsif($cloud_interconnect_id =~ m/-PRI-/){
+            $azure_peering_subnet = $ip->{properties}->{primaryPeerAddresssubnet};
+        }else{
+            $azure_peering_subnet = "";
+        }
+    }
+    return $azure_peering_subnet;
+}
+
+sub get_endpoint_peer{
+    my $endpoint = shift;
+    my $cloud_interconnect_id = shift;
+    my $cloud_account_id = shift;
+    my $peers = $endpoint->peers();
+    my $endpoint_ips =[];
+    if($endpoint->cloud_interconnect_id() eq $cloud_interconnect_id && $endpoint->cloud_account_id() eq $cloud_account_id){
+        foreach my $peer (@$peers){
+            my $cloud_connetions = $peer->{db}->{configuration}->{cloud}->{connection};
+            foreach my $conn (@$cloud_connetions){
+                if( $conn->{interconnect_id} eq $cloud_interconnect_id){
+                    return $peer;
+                } 
+            }
+        }
+    }
+    return undef;
+}
+
+sub update_endpoint_peer_ips{
+    my $db = shift;
+    my $azure_subnet = shift;
+    my $peer = shift;
+    my $new_oess_ip = increment_ip($azure_subnet, 1);
+    my $new_azure_ip = increment_ip($azure_subnet, 2);
+    my $logger = Log::Log4perl->get_logger('OESS.Cloud.Azure.Syncer');
+    $logger->info("UPDATEING AZURE PEERING: changing $peer->{local_ip} to $new_oess_ip, and changing $peer->{peer_ip} to $new_azure_ip");
+    $peer->{local_ip} = $new_oess_ip;
+    $peer->{peer_ip} = $new_azure_ip;
+    $peer->update($db, $peer->to_hash());
+    
+}
+
+sub increment_ip{
+    my $ip = shift;
+    my $increment = shift;
+    $ip =~ m/^(\d\d?\d?)\.(\d\d?\d?)\.(\d\d?\d?)\.(\d\d?\d?)/;
+    my $firstOctet = $1;
+    my $secondOctet = $2;
+    my $thirdOctet = $3;
+    my $lastOctet = $4;
+    $ip =~ m/\/(\d\d?)$/;
+    my $subnet = $1;
+    $lastOctet = int($lastOctet) + $increment;
+    return "$firstOctet.$secondOctet.$thirdOctet.$lastOctet/$subnet";
 }
 
 sub fetch_azure_cloud_account_configs{

--- a/perl-lib/OESS/lib/OESS/MPLS/Discovery/Paths.pm
+++ b/perl-lib/OESS/lib/OESS/MPLS/Discovery/Paths.pm
@@ -120,6 +120,9 @@ sub _process_paths{
         my @ckt_path = map { $links->{$_} } keys(%$links);
 
         my $ckt = new OESS::L2Circuit(db => $self->{db2}, circuit_id => $circuit_id);
+        if(!defined $ckt){
+            next;
+        }
         $ckt->load_paths;
 
         my $pri = $ckt->path(type => 'primary');


### PR DESCRIPTION
1098 - OESS now detects changes made via Azure portal and updates peering, adjusts OESS to match Azure.
Assumes peering will always be on a /30 subnet and OESS will be the first free address and Azure will be the last free address (i.e. does not take network or broadcast address).
logs changes to journalctl --follow
Uses could_account_id, and cloud_interconnect_id to match peering.
Also fixed issue in perl-lib/OESS/lib/OESS/MPLS/Discovery/Paths.pm so that if their is no matching circuit for a circuit_id in the OESS DB then the ID is skipped (i.e new OESS::L2Circuit returns undefined)