### PR TITLE
#1220 get workgroups loading wrong users workgroups

### DIFF
--- a/frontend/webservice/admin/admin.cgi
+++ b/frontend/webservice/admin/admin.cgi
@@ -1192,10 +1192,10 @@ sub edit_remote_link {
 
 }
 
+#Gets workgroups based on user_id given through parameter
 sub get_workgroups {
     my ($method, $args) = @_;
 
-    #my ($user, $err) = authorization(admin => 1, read_only => 1);
     my ($result, $err) = OESS::DB::User::has_system_access(db => $db2, username => $ENV{'REMOTE_USER'}, role=>'read-only');
     if (defined $err) {
         $method->set_error($err);
@@ -1217,7 +1217,6 @@ sub get_workgroups {
     $user->load_workgroups();
 
     $workgroups = $user->to_hash()->{workgroups};
-
     if ( !defined $workgroups ) {
         $results->{'error'}   = $db->get_error();
         $results->{'results'} = [];

--- a/frontend/webservice/admin/admin.cgi
+++ b/frontend/webservice/admin/admin.cgi
@@ -1201,13 +1201,19 @@ sub get_workgroups {
         $method->set_error($err);
         return;
     }
-
-    my %parameters = ( 'user_id' => $args->{'user_id'}{'value'} || undef );
-
     my $results;
-    my $workgroups;
+    my $user_id =  $args->{'user_id'}{'value'} || undef;
+    if(!defined $user_id){
+        $results->{'error'} = 'user_id is undefined';
+        return $results;
+    }
 
-    my $user = new OESS::User(db => $db2, username => $ENV{'REMOTE_USER'});
+    my $workgroups;
+    my $user = new OESS::User(db => $db2, user_id => $user_id);
+    if(!defined $user){
+        $results->{'error'} = 'user with the user_id \'' . $user_id . '\' was not found';
+        return $results;
+    }
     $user->load_workgroups();
 
     $workgroups = $user->to_hash()->{workgroups};


### PR DESCRIPTION
get_workgroups in admin.cgi now returns the workgroups of the given user_id. Fixes issue #1220 
Example method call:
`https://bsiefers-dev-7.grnoc.iu.edu/oess/services/admin/admin.cgi?method=get_workgroups&user_id=2`