### PR TITLE
#1216 limit visibility into l2 connections

### DIFF
--- a/frontend/webservice/data.cgi
+++ b/frontend/webservice/data.cgi
@@ -765,7 +765,13 @@ sub get_circuits_by_interface_id {
 	return;
     }
     else {
-        $results->{'results'} = $circuits;
+        my $circuit;
+        foreach(@{$circuits}){
+            my ($ok, $err) = OESS::DB::User::has_circuit_access(db => $db2, username => $ENV{'REMOTE_USER'}, circuit_id => $_->{'circuit_id'}, role => 'read-only');
+            if($ok){
+		push($results->{'results'}, $_);
+            }
+        }
     }
 
     return $results;
@@ -912,6 +918,11 @@ sub get_circuit_scheduled_events {
     my $results;
 
     my $circuit_id = $args->{'circuit_id'}{'value'};
+    my ($ok, $err) = OESS::DB::User::has_circuit_access(db => $db2, username => $ENV{'REMOTE_USER'}, circuit_id => $circuit_id, role => 'read-only');
+    if(!$ok){
+        $results->{'error'} = $err;
+        return $results;
+    }
 
     my $events = $db->get_circuit_scheduled_events( circuit_id => $circuit_id );
 
@@ -932,6 +943,12 @@ sub get_circuit_history {
     my $results;
 
     my $circuit_id = $args->{'circuit_id'}{'value'};
+    
+    my ($ok, $err) = OESS::DB::User::has_circuit_access(db => $db2, username => $ENV{'REMOTE_USER'}, circuit_id => $circuit_id, role => 'read-only');
+    if(!$ok){
+        $results->{'error'} = $err;
+        return $results;
+    }
 
     my $events = $db->get_circuit_history( circuit_id => $circuit_id );
 
@@ -951,7 +968,12 @@ sub get_circuit_details {
 
     my ( $method, $args ) = @_ ;
     my $circuit_id = $args->{'circuit_id'}{'value'};
-
+       
+    my ($ok, $err) = OESS::DB::User::has_circuit_access(db => $db2, username => $ENV{'REMOTE_USER'}, circuit_id => $circuit_id, role => 'read-only');
+    if(!$ok){
+        $results->{'error'} = $err;
+        return $results;
+    }
     my $ckt = OESS::Circuit->new( circuit_id => $circuit_id, db => $db);
     my $details = $ckt->get_details();
 
@@ -980,8 +1002,14 @@ sub get_circuit_details_by_external_identifier {
 	$method->set_error( $db->get_error() );
         return;
     }
+    my $circuit_id = $info->{'circuit_id'};
+    my ($ok, $err) = OESS::DB::User::has_circuit_access(db => $db2, username => $ENV{'REMOTE_USER'}, circuit_id => $circuit_id, role => 'read-only');
+    if(!$ok){
+        $results->{'error'} = $err;
+        return $results;
+    }
 
-    my $ckt = OESS::Circuit->new( circuit_id => $info->{'circuit_id'}, db => $db);
+    my $ckt = OESS::Circuit->new( circuit_id => $circuit_id, db => $db);
     my $details = $ckt->get_details();
 
     if ( !defined $details ) {
@@ -1191,9 +1219,13 @@ sub generate_clr {
     my $results;
 
     my $circuit_id = $args->{'circuit_id'}{'value'};
-
     if ( !defined($circuit_id) ) {
 	$method->set_error( "No Circuit ID Specified" );
+    }
+    my ($ok, $err) = OESS::DB::User::has_circuit_access(db => $db2, username => $ENV{'REMOTE_USER'}, circuit_id => $circuit_id, role => 'read-only');
+    if(!$ok){
+        $results->{'error'} = $err;
+        return $results;
     }
 
     my $ckt = OESS::Circuit->new( circuit_id => $circuit_id, db => $db);

--- a/frontend/webservice/measurement.cgi
+++ b/frontend/webservice/measurement.cgi
@@ -43,6 +43,7 @@ use OESS::Measurement qw(BUILDING_FILE);
 Log::Log4perl::init('/etc/oess/logging.conf');
 
 my $db          = new OESS::Database();
+my $db2         = new OESS::DB();
 my $measurement = new OESS::Measurement();
 
 #register web service dispatcher
@@ -153,6 +154,12 @@ sub get_circuit_data {
     my $interface  = $args->{'interface'}{'value'};
 
     my $link       = $args->{'link'}{'value'};
+    my ($ok, $err);
+    my ($ok, $err) = OESS::DB::User::has_circuit_access(db => $db2, username => 'bsiefers', circuit_id => $circuit_id, role => 'read-only');
+    if(!$ok){
+        $results->{'error'} = $err;
+        return $results;
+    }
 
     # if we were sent a link, pick one of the endpoints to use for gathering data
     if (defined $link){

--- a/frontend/webservice/measurement.cgi
+++ b/frontend/webservice/measurement.cgi
@@ -155,7 +155,7 @@ sub get_circuit_data {
 
     my $link       = $args->{'link'}{'value'};
     my ($ok, $err);
-    my ($ok, $err) = OESS::DB::User::has_circuit_access(db => $db2, username => 'bsiefers', circuit_id => $circuit_id, role => 'read-only');
+    my ($ok, $err) = OESS::DB::User::has_circuit_access(db => $db2, username => $ENV{'REMOTE_USER'}, circuit_id => $circuit_id, role => 'read-only');
     if(!$ok){
         $results->{'error'} = $err;
         return $results;

--- a/perl-lib/OESS/lib/OESS/DB/User.pm
+++ b/perl-lib/OESS/lib/OESS/DB/User.pm
@@ -642,6 +642,8 @@ sub has_workgroup_access {
 
 =head2 has_circuit_access
 
+=over
+
 =item db
     Denotes the database we are checking for access
 
@@ -663,7 +665,11 @@ sub has_workgroup_access {
                                   db           => $db,
                                   user_id      => $user_id,
                                   circuit_id => $circuit_id,
-                                  $role        => $role);
+    
+    
+    has_circuit_access checks if a specified user's role found in the circuit's associated workgroup, and has
+    appropriate access for that workgroup. The workgroup is accessed by getting the circuit with C<circuit_id> 
+    and then uses C<has_workgroup_access> to determine whether the user has access to the circuit.
 =cut
 sub has_circuit_access {
     my %params = @_;

--- a/perl-lib/OESS/lib/OESS/DB/User.pm
+++ b/perl-lib/OESS/lib/OESS/DB/User.pm
@@ -639,4 +639,63 @@ sub has_workgroup_access {
         }
     }
 }
+
+=head2 has_circuit_access
+
+=item db
+    Denotes the database we are checking for access
+
+=item user_id
+    Denotes the user_id of the user whose access we are checking
+
+=item username
+    Denotes the username of the user whose access we are checking
+
+=item circuit_id
+   Denotes the circuit_id of the circuit we checking the users permissions in
+
+=item role
+   Denotes the level of access the user needs for a particular action
+
+=back
+
+    my $results = OESS::DB::User::has_circuit_access(
+                                  db           => $db,
+                                  user_id      => $user_id,
+                                  circuit_id => $circuit_id,
+                                  $role        => $role);
+=cut
+sub has_circuit_access {
+    my %params = @_;
+    my $db = $params{'db'};
+    my $user_id = $params{'user_id'};
+    my $username = $params{'username'};
+    my $circuit_id = $params{'circuit_id'};
+    my $role = $params{'role'};
+    return (0, "Required argument 'db' is missing.") if !defined $db;
+    return (0, "Required to pass either 'user_id' or 'username'.") if !defined $user_id && !defined $username;
+    return (0, "Required argument 'circuit_id' is missing.") if !defined $circuit_id;
+    return (0, "Required argument 'role' is missing.") if !defined $role;
+    my $user;
+    if (!defined $user_id) {
+        $user = OESS::DB::User::fetch(db => $db, username => $username);
+    } else {
+        $user = OESS::DB::User::fetch(db => $db, user_id => $user_id);
+    }
+    
+    if (!defined $user || $user->{'status'} eq 'decom'){
+        return (0, "Invalid or decommissioned user specified.");
+    }
+
+    my $circuit = OESS::DB::Circuit::fetch_circuit(db => $db, circuit_id => $circuit_id)->[0];
+
+    if (!defined $circuit || $circuit->{'state'} eq 'decom'){ 
+        return (0, "Invalid or decommissioned circuit specified." );
+    }
+
+    $user_id = $user->{'user_id'};
+    my $workgroup_id = $circuit->{'workgroup_id'};
+    return has_workgroup_access(db => $db, user_id => $user_id, workgroup_id => $workgroup_id, role => $role);
+}
+
 1;

--- a/perl-lib/OESS/t/z-DB/User.has_circuit_access.00.t
+++ b/perl-lib/OESS/t/z-DB/User.has_circuit_access.00.t
@@ -36,7 +36,7 @@ my $db = new OESS::DB(
 my ($result, $error) = OESS::DB::User::has_circuit_access(db => $db, username => 'aragusa', circuit_id => 11, role => 'admin');
 ok($result == 1, "Got expected result '1'");
 
-($result, $error) = OESS::DB::User::has_circuit_access(db => $db, username => 'aragusa', circuit_id => 11, role => 'admin');
+($result, $error) = OESS::DB::User::has_circuit_access(db => $db, user_id => 11, circuit_id => 11, role => 'admin');
 ok($result == 1, "Got expected result '1'");
 
 ($result, $error) = OESS::DB::User::has_circuit_access(db => $db, user_id => 11, circuit_id => 11, role => 'normal');

--- a/perl-lib/OESS/t/z-DB/User.has_circuit_access.00.t
+++ b/perl-lib/OESS/t/z-DB/User.has_circuit_access.00.t
@@ -1,0 +1,57 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use FindBin;
+my $path;
+
+BEGIN {
+    if ($FindBin::Bin =~ /(.*)/) {
+        $path = $1;
+    }
+}
+use lib "$path/..";
+
+use Data::Dumper;
+use Test::More tests => 7;
+
+use OESSDatabaseTester;
+
+use OESS::DB;
+use OESS::DB::User;
+use OESS::DB::Workgroup;
+use OESS::DB::Circuit;
+
+OESSDatabaseTester::resetOESSDB(
+    config => "$path/../conf/database.xml",
+    dbdump => "$path/../conf/oess_known_state.sql"
+);
+
+my $db = new OESS::DB(
+    config => "$path/../conf/database.xml"
+);
+
+
+my ($result, $error) = OESS::DB::User::has_circuit_access(db => $db, username => 'aragusa', circuit_id => 11, role => 'admin');
+ok($result == 1, "Got expected result '1'");
+
+($result, $error) = OESS::DB::User::has_circuit_access(db => $db, username => 'aragusa', circuit_id => 11, role => 'admin');
+ok($result == 1, "Got expected result '1'");
+
+($result, $error) = OESS::DB::User::has_circuit_access(db => $db, user_id => 11, circuit_id => 11, role => 'normal');
+ok($result == 1, "Got expected result '1'");
+
+($result, $error) = OESS::DB::User::has_circuit_access(db => $db, user_id => 11, circuit_id => 11, role => 'read-only');
+ok($result == 1, "Got expected result '1'");
+
+($result, $error) = OESS::DB::User::has_circuit_access(db => $db, user_id => 901, circuit_id => 11, role => 'admin');
+ok(defined $error, "Got expected error, $error");
+
+($result, $error) = OESS::DB::User::has_circuit_access(db => $db, user_id => 901, circuit_id => 11, role => 'noraml');
+ok(defined $error, "Got expected error, $error");
+
+($result, $error) = OESS::DB::User::has_circuit_access(db => $db, user_id => 901, circuit_id => 11, role => 'read-only');
+ok(defined $error, "Got expected error, $error");
+
+


### PR DESCRIPTION
Fixes #1216 

Added changes to limit circuit visibility to those that have the correct workgroup credentials. 

Changes to note:
When a circuit doesn't exist you will receive an error that says that it doesn't exist or has been decommissioned. This is important if any functions depend on receiving an empty array if that circuit doesn't exist or the user doesn't have correct credentials. The only exception is get_circuits_by_interface_id where any circuit that the user doesn't have access to is simply left out.