### PR TITLE
update bandwidth validation for non-cloud interfaces

### DIFF
--- a/perl-lib/OESS/lib/OESS/Interface.pm
+++ b/perl-lib/OESS/lib/OESS/Interface.pm
@@ -27,6 +27,7 @@ sub new{
         interface_id => undef,
         logger       => Log::Log4perl->get_logger("OESS.Interface"),
         model        => undef,
+        bandwidth_validator_config => "/etc/oess/interface-speed-config.xml",
         @_
     );
 
@@ -496,8 +497,10 @@ sub is_bandwidth_valid {
         @_
     };
 
+    # Normal interfaces are not intended to limit the flow of traffic. Return 0
+    # if a user specifies a bandwidth other than 0 on this interface. 
     if (!defined $self->cloud_interconnect_type) {
-        return 1;
+        return ($args->{bandwidth} == 0) ? 1 : 0;
     }
 
     if ($self->cloud_interconnect_type eq 'aws-hosted-vinterface') {
@@ -505,8 +508,8 @@ sub is_bandwidth_valid {
     }
 
     my $validator = new OESS::Cloud::BandwidthValidator(
-        config => "/etc/oess/interface-speed-config.xml",
-        interface => $self
+        config_path => $self->{bandwidth_validator_config},
+        interface   => $self
     );
     $validator->load;
 

--- a/perl-lib/OESS/t/z-Object/Interface.is_bandwidth_valid.00.t
+++ b/perl-lib/OESS/t/z-Object/Interface.is_bandwidth_valid.00.t
@@ -1,0 +1,49 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use FindBin;
+my $path;
+
+BEGIN {
+    if ($FindBin::Bin =~ /(.*)/) {
+        $path = $1;
+    }
+}
+use lib "$path/..";
+
+
+use Data::Dumper;
+use Test::More tests => 5;
+
+use OESSDatabaseTester;
+
+use OESS::DB;
+use OESS::Interface;
+
+
+OESSDatabaseTester::resetOESSDB(
+    config => "$path/../conf/database.xml",
+    dbdump => "$path/../conf/oess_known_state.sql"
+);
+
+
+my $db = new OESS::DB(
+    config  => "$path/../conf/database.xml"
+);
+
+my $intf = new OESS::Interface(
+    db => $db,
+    interface_id => 511,
+    bandwidth_validator_config => "$path/../conf/interface-speed-config.xml"
+);
+ok($intf->interface_id eq '511', 'Correct interface_id');
+ok($intf->is_bandwidth_valid(bandwidth => 0) == 1, 'Correct bandwidth validation for normal interface returned');
+ok($intf->is_bandwidth_valid(bandwidth => 1000) == 0, 'Correct bandwidth validation for normal interface returned');
+
+$intf->{cloud_interconnect_type} = 'aws-hosted-connection';
+$intf->update_db;
+
+ok($intf->is_bandwidth_valid(bandwidth => 0) == 0, 'Correct bandwidth validation for cloud interface returned');
+ok($intf->is_bandwidth_valid(bandwidth => 1000) == 1, 'Correct bandwidth validation for cloud interface returned');


### PR DESCRIPTION
Normal interfaces are not intended to limit the flow of traffic. If a user
specifies a bandwidth other than 0 on one of these interfaces, bandwidth
validation now fails. Fixes #1330