### PR TITLE
Add support for multiple ExpressRouteCrossConnections per Connection

### DIFF
--- a/frontend/webservice/circuit.cgi
+++ b/frontend/webservice/circuit.cgi
@@ -414,7 +414,7 @@ sub provision {
 
     if (!$args->{skip_cloud_provisioning}->{value}) {
         eval {
-            OESS::Cloud::setup_endpoints($circuit->description, $circuit->endpoints, $is_admin);
+            OESS::Cloud::setup_endpoints($db, undef, $circuit->description, $circuit->endpoints, $is_admin);
 
             foreach my $ep (@{$circuit->endpoints}) {
                 # It's expected that layer2 connections to azure pass
@@ -661,7 +661,7 @@ sub update {
     if (!$args->{skip_cloud_provisioning}{value}) {
         eval {
             OESS::Cloud::cleanup_endpoints($del_endpoints);
-            OESS::Cloud::setup_endpoints($circuit->description, $add_endpoints, $is_admin);
+            OESS::Cloud::setup_endpoints($db, undef, $circuit->description, $add_endpoints, $is_admin);
 
             foreach my $ep (@{$circuit->endpoints}) {
                 # It's expected that layer2 connections to azure pass

--- a/frontend/webservice/vrf.cgi
+++ b/frontend/webservice/vrf.cgi
@@ -14,6 +14,7 @@ use GRNOC::WebService::Dispatcher;
 use OESS::RabbitMQ::Client;
 use OESS::RabbitMQ::Topic qw(fwdctl_topic_for_connection);
 use OESS::Cloud;
+use OESS::Cloud::AzurePeeringConfig;
 use OESS::Config;
 use OESS::DB;
 use OESS::DB::User;
@@ -327,6 +328,7 @@ sub provision_vrf{
 
     my $vrf = undef;
     my $previous_vrf = undef;
+    my $azure_peering_config = new OESS::Cloud::AzurePeeringConfig(db => $db);
 
     if (defined $model->{'vrf_id'} && $model->{'vrf_id'} != -1) {
         $vrf = OESS::VRF->new(db => $db, vrf_id => $model->{vrf_id});
@@ -345,6 +347,8 @@ sub provision_vrf{
 
         $vrf->last_modified_by($user);
         $vrf->update;
+
+        $azure_peering_config->load($vrf->vrf_id);
     } else {
         $model->{created_by_id} = $user->user_id;
         $model->{last_modified_by_id} = $user->user_id;
@@ -489,35 +493,24 @@ sub provision_vrf{
                 }
 
                 if ($interface->cloud_interconnect_type eq 'azure-express-route') {
-                    my $peer;
+                    my $prefix;
                     if ($endpoint->cloud_interconnect_id =~ /PRI/) {
-                        # pri_prefix: '192.168.100.248/30';
-                        $peer = new OESS::Peer(
-                            db => $db,
-                            model => {
-                                peer_asn    => 12076,
-                                md5_key     => '',
-                                local_ip    => '192.168.100.249/30',
-                                peer_ip     => '192.168.100.250/30',
-                                ip_version  => 'ipv4',
-                                bfd         => $peering->{bfd}
-                            }
-                        );
+                        $prefix = $azure_peering_config->primary_prefix($endpoint->{cloud_account_id}, $peering->{ip_version});
                     } else {
-                        # sec_prefix: '192.168.100.252/30';
-                        $peer = new OESS::Peer(
-                            db => $db,
-                            model => {
-                                peer_asn    => 12076,
-                                md5_key     => '',
-                                local_ip    => '192.168.100.253/30',
-                                peer_ip     => '192.168.100.254/30',
-                                ip_version  => 'ipv4',
-                                bfd         => $peering->{bfd}
-                            }
-                        );
+                        $prefix = $azure_peering_config->secondary_prefix($endpoint->{cloud_account_id}, $peering->{ip_version});
                     }
 
+                    my $peer = new OESS::Peer(
+                        db => $db,
+                        model => {
+                            peer_asn    => 12076,
+                            md5_key     => '',
+                            local_ip    => $azure_peering_config->nth_address($prefix, 1),
+                            peer_ip     => $azure_peering_config->nth_address($prefix, 2),
+                            ip_version  => $peering->{ip_version},
+                            bfd         => $peering->{bfd}
+                        }
+                    );
                     my ($peer_id, $peer_err) = $peer->create(vrf_ep_id => $endpoint->vrf_endpoint_id);
                     if (defined $peer_err) {
                         $method->set_error($peer_err);
@@ -526,7 +519,7 @@ sub provision_vrf{
                     }
                     $endpoint->add_peer($peer);
 
-                    $peerings->{"$endpoint->{node} $endpoint->{interface} $peering->{local_ip}"} = 1;
+                    $peerings->{"$endpoint->{node} $endpoint->{interface} $peer->{local_ip}"} = 1;
                     next;
                 }
 
@@ -623,6 +616,41 @@ sub provision_vrf{
                         next;
                     }
 
+                    # Updating a Cloud Connect Endpoint is unsupported, however
+                    # we still try to provide a consistent experience to the
+                    # user. Updating an Azure Endpoint's peerings must be done
+                    # via the Azure Portal.
+                    if ($endpoint->cloud_interconnect_type eq 'azure-express-route') {
+                        my $prefix;
+                        if ($endpoint->cloud_interconnect_id =~ /PRI/) {
+                            $prefix = $azure_peering_config->primary_prefix($endpoint->{cloud_account_id}, $peering->{ip_version});
+                        } else {
+                            $prefix = $azure_peering_config->secondary_prefix($endpoint->{cloud_account_id}, $peering->{ip_version});
+                        }
+
+                        my $peer = new OESS::Peer(
+                            db => $db,
+                            model => {
+                                peer_asn    => 12076,
+                                md5_key     => '',
+                                local_ip    => $azure_peering_config->nth_address($prefix, 1),
+                                peer_ip     => $azure_peering_config->nth_address($prefix, 2),
+                                ip_version  => $peering->{ip_version},
+                                bfd         => $peering->{bfd}
+                            }
+                        );
+                        my ($peer_id, $peer_err) = $peer->create(vrf_ep_id => $endpoint->vrf_endpoint_id);
+                        if (defined $peer_err) {
+                            $method->set_error($peer_err);
+                            $db->rollback;
+                            return;
+                        }
+                        $endpoint->add_peer($peer);
+
+                        $peerings->{"$endpoint->{node} $endpoint->{interface} $peering->{local_ip}"} = 1;
+                        next;
+                    }
+    
                     # Peerings not auto-generated for non-cloud endpoints
                     if (defined $endpoint->{cloud_account_id} && $endpoint->{cloud_account_id} eq '') {
                         next;
@@ -708,7 +736,7 @@ sub provision_vrf{
     if (!$params->{skip_cloud_provisioning}{value}) {
         eval {
             OESS::Cloud::cleanup_endpoints($del_endpoints);
-            OESS::Cloud::setup_endpoints($vrf->name, $add_endpoints, $is_admin);
+            OESS::Cloud::setup_endpoints($db, $vrf->vrf_id, $vrf->name, $add_endpoints, $is_admin);
 
             foreach my $ep (@{$vrf->endpoints}) {
                 # It's expected that layer2 connections to azure pass

--- a/perl-lib/OESS/lib/OESS/Cloud/AzurePeeringConfig.pm
+++ b/perl-lib/OESS/lib/OESS/Cloud/AzurePeeringConfig.pm
@@ -1,0 +1,351 @@
+package OESS::Cloud::AzurePeeringConfig;
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+use Log::Log4perl;
+use Net::IP;
+
+use OESS::DB::Endpoint;
+use OESS::Endpoint;
+
+=head1 OESS::Cloud::AzurePeeringConfig
+
+Loads the peering information required to provision an ExpressRoute
+CrossConnection from the OESS database.
+
+
+    {
+        '000-0000-000' => {
+            'ipv4' => {
+                'primary'   => '192.168.100.248/30',
+                'secondary' => '192.168.100.252/30',
+            'ipv6' => {
+                primary   => "3FFE:FFFF:0:CD30::0/126",
+                secondary => "3FFE:FFFF:0:CD30::4/126",
+            }
+        }
+    }
+
+=cut
+
+=head2 new
+
+    my $config = new OESS::Cloud::AzurePeeringConfig(
+        db     => $db,
+        vrf_id => $conn->vrf_id # Optional
+    );
+
+=cut
+sub new {
+    my $class = shift;
+    my $args  = {
+        db     => undef,
+        logger => Log::Log4perl->get_logger('OESS.Cloud.AzurePeeringConfig'),
+        @_
+    };
+    my $self = bless $args, $class;
+
+    die "Argument 'db' was not passed to AzurePeeringConfig" if !defined $self->{db};
+
+    $self->{prefixes} = {};
+
+    $self->{next_v4_prefix} = $self->_prefix_from_address('192.168.100.250/30');
+    $self->{next_v6_prefix} = $self->_prefix_from_address('3FFE:FFFF:0:CD30::2/126');
+
+    return $self;
+}
+
+=head2 load
+
+    my $ok = $config->load(123);
+
+=cut
+sub load {
+    my $self   = shift;
+    my $vrf_id = shift;
+
+    die "Argument 'vrf_id' was not passed to AzurePeeringConfig" if !defined $vrf_id;
+
+    my ($models, $err) = OESS::DB::Endpoint::fetch_all(
+        db     => $self->{db},
+        vrf_id => $vrf_id
+    );
+    warn $err if defined $err;
+
+    foreach my $model (@$models) {
+        next if !defined $model->{cloud_interconnect_type} || $model->{cloud_interconnect_type} ne 'azure-express-route';
+        warn "ok";
+
+        my $ep = new OESS::Endpoint(db => $self->{db}, vrf_endpoint_id => $model->{vrf_ep_id});
+        $ep->load_peers;
+
+        foreach my $peer (@{$ep->peers}) {
+            my $v = ($peer->ip_version eq 'ipv4') ? 4 : 6;
+
+            if ($ep->cloud_interconnect_id =~ /PRI/) {
+                $self->{prefixes}->{$ep->cloud_account_id}->{$v}->{primary} = $self->_prefix_from_address($peer->local_ip);
+
+            } else {
+                $self->{prefixes}->{$ep->cloud_account_id}->{$v}->{secondary} = $self->_prefix_from_address($peer->local_ip);
+            }
+
+            # TODO Validate next_v*_prefixes not already in use. Handles case where subnet
+            # set from azure side. As prefixes set on Azure side override those stored in
+            # OESS db, conflicts should only last a short period of time.
+
+            # Prefixes are selected starting from a pre-defined subnet. So long as we
+            # increment the subnet once for every subnet in use, we should have a unique
+            # prefix.
+            if ($v == 4) {
+                $self->{next_v4_prefix} = $self->_next_prefix($self->{next_v4_prefix});
+            } else {
+                $self->{next_v6_prefix} = $self->_next_prefix($self->{next_v6_prefix});
+            }
+        }
+    }
+
+    return 1;
+}
+
+=head2 primary_prefix
+
+    my $prefix = $config->primary_prefix($service_id, $peer->ip_version);
+
+primary_prefix returns the primary prefix to be used with $service_id as a
+string.
+
+Example:
+
+    192.168.100.248/30
+
+=cut
+sub primary_prefix {
+    my $self    = shift;
+    my $service = shift;
+    my $version = shift;
+
+    my $v = ($version eq 'ipv4') ? 4 : 6;
+
+    if (!defined $self->{prefixes}->{$service}) {
+        $self->{prefixes}->{$service} = {
+            4 => { primary => undef, secondary => undef },
+            6 => { primary => undef, secondary => undef },
+        };
+    }
+
+    if (!defined $self->{prefixes}->{$service}->{$v}->{primary}) {
+        if ($v == 4) {
+            $self->{prefixes}->{$service}->{$v}->{primary} = $self->{next_v4_prefix};
+            $self->{next_v4_prefix} = $self->_next_prefix($self->{next_v4_prefix});
+        } else {
+            $self->{prefixes}->{$service}->{$v}->{primary} = $self->{next_v6_prefix};
+            $self->{next_v6_prefix} = $self->_next_prefix($self->{next_v6_prefix});
+        }
+    }
+
+    return $self->{prefixes}->{$service}->{$v}->{primary}->ip . '/' . $self->{prefixes}->{$service}->{$v}->{primary}->prefixlen;
+}
+
+=head2 secondary_prefix
+
+    my $prefix = $config->secondary_prefix($service_id, $peer->ip_version);
+
+secondary_prefix returns the secondary prefix to be used with $service_id as a
+string.
+
+Example:
+
+    192.168.100.248/30
+
+=cut
+sub secondary_prefix {
+    my $self    = shift;
+    my $service = shift;
+    my $version = shift;
+
+    my $v = ($version eq 'ipv4') ? 4 : 6;
+
+    if (!defined $self->{prefixes}->{$service}) {
+        $self->{prefixes}->{$service} = {
+            4 => { primary => undef, secondary => undef },
+            6 => { primary => undef, secondary => undef },
+        };
+    }
+
+    if (!defined $self->{prefixes}->{$service}->{$v}->{secondary}) {
+        if ($v == 4) {
+            $self->{prefixes}->{$service}->{$v}->{secondary} = $self->{next_v4_prefix};
+            $self->{next_v4_prefix} = $self->_next_prefix($self->{next_v4_prefix});
+        } else {
+            $self->{prefixes}->{$service}->{$v}->{secondary} = $self->{next_v6_prefix};
+            $self->{next_v6_prefix} = $self->_next_prefix($self->{next_v6_prefix});
+        }
+    }
+
+    return $self->{prefixes}->{$service}->{$v}->{secondary}->ip . '/' . $self->{prefixes}->{$service}->{$v}->{secondary}->prefixlen;
+}
+
+=head2 cross_connection_peering
+
+The result of cross_connection_peering is used as the argument for peering in
+set_cross_connection_state_to_provisioned.
+
+Example:
+    {
+        primaryPeerAddressPrefix   => '192.168.100.0/30'
+        secondaryPeerAddressPrefix => '192.168.100.4/30',
+        ipv6PeeringConfig => {
+            primaryPeerAddressPrefix   => "3FFE:FFFF:0:CD30::0/126",
+            secondaryPeerAddressPrefix => "3FFE:FFFF:0:CD30::4/126"
+        }
+    }
+
+=cut
+sub cross_connection_peering {
+    my $self = shift;
+    my $service = shift;
+
+    my $result = {};
+    if (!defined $self->{prefixes}->{$service}) {
+        return $result;
+    }
+
+    my $v4 = $self->{prefixes}->{$service}->{4};
+    my $v6 = $self->{prefixes}->{$service}->{6};
+
+    if (defined $v4->{primary} || defined $v4->{secondary}) {
+        # If only one prefix is passed, provisioning doesn't appear to work. So
+        # we send both regardless of usage.
+        $result->{primaryPeerAddressPrefix} = $self->primary_prefix($service, 'ipv4');
+        $result->{secondaryPeerAddressPrefix} = $self->secondary_prefix($service, 'ipv4');
+        $result->{state} = 'Enabled';
+        $result->{peeringType} = 'AzurePrivatePeering';
+    }
+
+    # NOTE: I thought IPv6 support was added, but it doesn't seem to apply to
+    # newly provisioned connections. Instead the user must add their IPv6
+    # prefixes via the Azure Portal. The syncer script will pull the Ipv6
+    # prefix in. If support for IPv6 is ever added uncomment the below section.
+    #
+    # if (defined $v6->{primary} || defined $v6->{secondary}) {
+    #     $result->{ipv6PeeringConfig} = {
+    #         primaryPeerAddressPrefix => $self->primary_prefix($service, 'ipv6'),
+    #         secondaryPeerAddressPrefix => $self->secondary_prefix($service, 'ipv6'),
+    #         state => 'Enabled'
+    #     };
+    # }
+
+    return $result;
+}
+
+=head2 nth_address
+
+Returns the nth IP Address of the provided subnet. An $increment of zero will
+return the network address.
+
+Examples:
+
+    my $ipv6 = get_nth_ip("2001:db8:85a3::8a2e:370:7334/126", 1);
+    # $ipv6 will equal "2001:db8:85a3::8a2e:370:7335/126"
+
+    my $ipv4 = get_nth_ip("192.168.100.248/30", 1);
+    # $ipv4 will equal "192.168.100.249/30"
+
+=cut
+sub nth_address {
+    my $self = shift;
+    my $prefix = shift;
+    my $increment = shift;
+
+    my $ip = new Net::IP($prefix);
+    my $mask = $ip->prefixlen();
+
+    my $new_ip   = $ip + $increment;
+    my $new_addr = $new_ip->ip . "/$mask";
+
+    return $new_addr;
+}
+
+=head2 _next_prefix
+
+_next_prefix finds the next available /30 or /126 based on which prefixes are
+currently recorded in this object.
+
+=cut
+sub _next_prefix {
+    my $self = shift;
+    my $prefix = shift;
+
+    my $one;
+    if ($prefix->version == 4) {
+        $one = new Net::IP('0.0.0.1');
+    } else {
+        $one = new Net::IP('::1');
+    }
+    my $new = new Net::IP($prefix->last_ip);
+    $new = $new->binadd($one);
+
+    $new->set($new->ip . "/" . $prefix->prefixlen);
+    return $new;
+}
+
+=head2 _prefix_from_address
+
+_prefix_from_address determines the network for the given address. For
+example, the network for 192.168.1.100/24 is 192.168.1.0/24.
+
+=cut
+sub _prefix_from_address {
+    my $self = shift;
+    my $addr = shift;
+
+    my @parts = split('/', $addr);
+    my $ipstr = $parts[0];
+    my $maskbits = $parts[1];
+
+    my $ip = new Net::IP($ipstr);
+    my $mask = Net::IP::ip_get_mask($maskbits, $ip->version);
+
+    my $netbin = $self->_ip_binand($ip->binip, $mask);
+    my $net = Net::IP::ip_bintoip($netbin, $ip->version);
+
+    return new Net::IP("$net/$maskbits");
+}
+
+=head2 _prefix_from_ip
+
+=cut
+sub _prefix_from_ip {
+    my $self = shift;
+    my $ip   = shift;
+    return $ip->ip . '/' . $ip->prefixlen;
+}
+
+=head2 _ip_binand
+
+Performs a binary and of the two binary string addresses.
+
+=cut
+sub _ip_binand {
+    my $self = shift;
+    my $a = shift;
+    my $b = shift;
+
+    if (length($a) ne length($b)) {
+        die  "Unequal length of addresses";
+    }
+
+    my $result = "";
+    for (0 .. length($a) - 1) {
+        if (substr($a, $_, 1) eq "1" && substr($b, $_, 1) eq "1") {
+            $result .= "1";
+        } else {
+            $result .= "0";
+        }
+    }
+    return $result;
+}
+
+return 1;

--- a/perl-lib/OESS/t/z-Object/Cloud/AzurePeeringConfig.load.00.t
+++ b/perl-lib/OESS/t/z-Object/Cloud/AzurePeeringConfig.load.00.t
@@ -1,0 +1,91 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use FindBin;
+my $path;
+
+BEGIN {
+    if ($FindBin::Bin =~ /(.*)/) {
+        $path = $1;
+    }
+}
+use lib "$path/../..";
+
+
+use Data::Dumper;
+use Test::More tests => 5;
+
+use OESSDatabaseTester;
+
+use OESS::DB;
+use OESS::Cloud::AzureStub;
+use OESS::Cloud::AzurePeeringConfig;
+use OESS::Config;
+
+OESSDatabaseTester::resetOESSDB(
+    config => "$path/../../conf/database.xml",
+    dbdump => "$path/../../conf/oess_known_state.sql"
+);
+
+
+my $db = new OESS::DB(config => "$path/../../conf/database.xml");
+
+$db->execute_query(
+    "update interface set cloud_interconnect_type='azure-express-route', cloud_interconnect_id=?, workgroup_id=? where interface_id=?",
+    ["OessTest-SJC-TEST-00GMR-CIS-1-PRI-A", 21, 40871]
+);
+$db->execute_query(
+    "update interface set cloud_interconnect_type='azure-express-route', cloud_interconnect_id=?, workgroup_id=? where interface_id=?",
+    ["OessTest-SJC-TEST-00GMR-CIS-2-SEC-A", 21, 40891]
+);
+my $ni_id = $db->execute_query(
+    "insert into node_instantiation (node_id,start_epoch,end_epoch,admin_state,dpid,openflow,mpls,controller) values (?,UNIX_TIMESTAMP(NOW()),-1,'active',987654567,0,1,'nso')",
+    [5071]
+);
+
+my $vrf_id = $db->execute_query(
+    "insert into vrf (name,description,workgroup_id,state,local_asn,created_by,last_modified_by) values (?,?,?,?,?,?,?)",
+    ["demo","demo",21,"active",64789,1,1]
+);
+
+my $ep1_id = $db->execute_query(
+    "insert into vrf_ep (vrf_id,interface_id,unit,tag,bandwidth,state,mtu) values (?,?,?,?,?,?,?)",
+    [$vrf_id,40871,100,100,0,"active",1500]
+);
+my $ep2_id = $db->execute_query(
+    "insert into vrf_ep (vrf_id,interface_id,unit,tag,bandwidth,state,mtu) values (?,?,?,?,?,?,?)",
+    [$vrf_id,40891,100,100,0,"active",1500]
+);
+
+my $pr1_id = $db->execute_query(
+    "insert into vrf_ep_peer (vrf_ep_id,ip_version,state,operational_state,local_ip,peer_ip,peer_asn) values (?,?,?,?,?,?,?)",
+    [$ep1_id,"ipv4","active",1,"192.168.100.249/30","192.168.100.250/30",12076]
+);
+my $pr2_id = $db->execute_query(
+    "insert into vrf_ep_peer (vrf_ep_id,ip_version,state,operational_state,local_ip,peer_ip,peer_asn) values (?,?,?,?,?,?,?)",
+    [$ep2_id,"ipv4","active",1,"192.168.100.253/30","192.168.100.254/30",12076]
+);
+
+my $cld_ep1_id = $db->execute_query(
+    "insert into cloud_connection_vrf_ep (vrf_ep_id,cloud_account_id,cloud_connection_id) values (?,?,?)",
+    [$ep1_id,"11111111-1111-1111-1111-111111111111","/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CrossConnection-SiliconValleyTest/providers/Microsoft.Network/expressRouteCrossConnections/11111111-1111-1111-1111-111111111111"]
+);
+my $cld_ep2_id = $db->execute_query(
+    "insert into cloud_connection_vrf_ep (vrf_ep_id,cloud_account_id,cloud_connection_id) values (?,?,?)",
+    [$ep2_id,"11111111-1111-1111-1111-111111111111","/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CrossConnection-SiliconValleyTest/providers/Microsoft.Network/expressRouteCrossConnections/11111111-1111-1111-1111-111111111111"]
+);
+
+my $config = new OESS::Cloud::AzurePeeringConfig(db => $db);
+$config->load($vrf_id);
+
+# Verifies that new subnets are allocated which do not overlap existing prefixes
+ok($config->primary_prefix("11111111-1111-1111-2222-111111111111", 'ipv4') eq '192.168.101.0/30', 'Got expected v4 address');
+
+ok($config->primary_prefix("11111111-1111-1111-1111-111111111111", 'ipv4') eq '192.168.100.248/30', 'Got expected v4 address');
+ok($config->secondary_prefix("11111111-1111-1111-1111-111111111111", 'ipv4') eq '192.168.100.252/30', 'Got expected v4 address');
+
+ok($config->primary_prefix("11111111-1111-1111-2222-111111111111", 'ipv4') eq '192.168.101.0/30', 'Got expected v4 address');
+
+ok($config->primary_prefix("11111111-1111-1111-3333-111111111111", 'ipv4') eq '192.168.101.4/30', 'Got expected v4 address');

--- a/perl-lib/OESS/t/z-Object/Cloud/AzurePeeringConfig.new.00.t
+++ b/perl-lib/OESS/t/z-Object/Cloud/AzurePeeringConfig.new.00.t
@@ -1,0 +1,40 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use FindBin;
+my $path;
+
+BEGIN {
+    if ($FindBin::Bin =~ /(.*)/) {
+        $path = $1;
+    }
+}
+use lib "$path/../..";
+
+
+use Data::Dumper;
+use Test::More tests => 2;
+
+use OESSDatabaseTester;
+
+use OESS::DB;
+use OESS::Cloud::AzureStub;
+use OESS::Cloud::AzurePeeringConfig;
+use OESS::Config;
+
+OESSDatabaseTester::resetOESSDB(
+    config => "$path/../../conf/database.xml",
+    dbdump => "$path/../../conf/oess_known_state.sql"
+);
+
+
+my $db = new OESS::DB(config => "$path/../../conf/database.xml");
+
+
+my $config = new OESS::Cloud::AzurePeeringConfig(db => $db);
+# warn Dumper($config);
+
+ok($config->{next_v4_prefix}->print eq '192.168.100.248/30', 'Got expected v4 address');
+ok($config->{next_v6_prefix}->print eq '3ffe:ffff:0:cd30::/126', 'Got expected v6 address');

--- a/perl-lib/OESS/t/z-Object/Cloud/AzurePeeringConfig.primary_prefix.00.t
+++ b/perl-lib/OESS/t/z-Object/Cloud/AzurePeeringConfig.primary_prefix.00.t
@@ -1,0 +1,54 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use FindBin;
+my $path;
+
+BEGIN {
+    if ($FindBin::Bin =~ /(.*)/) {
+        $path = $1;
+    }
+}
+use lib "$path/../..";
+
+
+use Data::Dumper;
+use Test::More tests => 12;
+
+use OESSDatabaseTester;
+
+use OESS::DB;
+use OESS::Cloud::AzureStub;
+use OESS::Cloud::AzurePeeringConfig;
+use OESS::Config;
+
+OESSDatabaseTester::resetOESSDB(
+    config => "$path/../../conf/database.xml",
+    dbdump => "$path/../../conf/oess_known_state.sql"
+);
+
+
+my $db = new OESS::DB(config => "$path/../../conf/database.xml");
+
+
+my $config = new OESS::Cloud::AzurePeeringConfig(db => $db);
+
+ok($config->primary_prefix('s1', 'ipv4') eq '192.168.100.248/30', 'Got expected v4 address');
+ok($config->primary_prefix('s1', 'ipv6') eq '3ffe:ffff:0000:cd30:0000:0000:0000:0000/126', 'Got expected v6 address');
+
+ok($config->primary_prefix('s1', 'ipv4') eq '192.168.100.248/30', 'Got expected v4 address');
+ok($config->primary_prefix('s1', 'ipv6') eq '3ffe:ffff:0000:cd30:0000:0000:0000:0000/126', 'Got expected v6 address');
+
+ok($config->primary_prefix('s2', 'ipv4') eq '192.168.100.252/30', 'Got expected v4 address');
+ok($config->primary_prefix('s2', 'ipv6') eq '3ffe:ffff:0000:cd30:0000:0000:0000:0004/126', 'Got expected v6 address');
+
+ok($config->primary_prefix('s2', 'ipv4') eq '192.168.100.252/30', 'Got expected v4 address');
+ok($config->primary_prefix('s2', 'ipv6') eq '3ffe:ffff:0000:cd30:0000:0000:0000:0004/126', 'Got expected v6 address');
+
+ok($config->primary_prefix('s3', 'ipv4') eq '192.168.101.0/30', 'Got expected v4 address');
+ok($config->primary_prefix('s3', 'ipv6') eq '3ffe:ffff:0000:cd30:0000:0000:0000:0008/126', 'Got expected v6 address');
+
+ok($config->primary_prefix('s3', 'ipv4') eq '192.168.101.0/30', 'Got expected v4 address');
+ok($config->primary_prefix('s3', 'ipv6') eq '3ffe:ffff:0000:cd30:0000:0000:0000:0008/126', 'Got expected v6 address');

--- a/perl-lib/OESS/t/z-Object/Cloud/AzurePeeringConfig.secondary_prefix.00.t
+++ b/perl-lib/OESS/t/z-Object/Cloud/AzurePeeringConfig.secondary_prefix.00.t
@@ -1,0 +1,57 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use FindBin;
+my $path;
+
+BEGIN {
+    if ($FindBin::Bin =~ /(.*)/) {
+        $path = $1;
+    }
+}
+use lib "$path/../..";
+
+
+use Data::Dumper;
+use Test::More tests => 14;
+
+use OESSDatabaseTester;
+
+use OESS::DB;
+use OESS::Cloud::AzureStub;
+use OESS::Cloud::AzurePeeringConfig;
+use OESS::Config;
+
+OESSDatabaseTester::resetOESSDB(
+    config => "$path/../../conf/database.xml",
+    dbdump => "$path/../../conf/oess_known_state.sql"
+);
+
+
+my $db = new OESS::DB(config => "$path/../../conf/database.xml");
+
+
+my $config = new OESS::Cloud::AzurePeeringConfig(db => $db);
+
+ok($config->primary_prefix('s1', 'ipv4') eq '192.168.100.248/30', 'Got expected v4 address');
+ok($config->primary_prefix('s1', 'ipv6') eq '3ffe:ffff:0000:cd30:0000:0000:0000:0000/126', 'Got expected v6 address');
+
+ok($config->secondary_prefix('s1', 'ipv4') eq '192.168.100.252/30', 'Got expected v4 address');
+ok($config->secondary_prefix('s1', 'ipv6') eq '3ffe:ffff:0000:cd30:0000:0000:0000:0004/126', 'Got expected v6 address');
+
+ok($config->secondary_prefix('s1', 'ipv4') eq '192.168.100.252/30', 'Got expected v4 address');
+ok($config->secondary_prefix('s1', 'ipv6') eq '3ffe:ffff:0000:cd30:0000:0000:0000:0004/126', 'Got expected v6 address');
+
+ok($config->secondary_prefix('s2', 'ipv4') eq '192.168.101.0/30', 'Got expected v4 address');
+ok($config->secondary_prefix('s2', 'ipv6') eq '3ffe:ffff:0000:cd30:0000:0000:0000:0008/126', 'Got expected v6 address');
+
+ok($config->secondary_prefix('s2', 'ipv4') eq '192.168.101.0/30', 'Got expected v4 address');
+ok($config->secondary_prefix('s2', 'ipv6') eq '3ffe:ffff:0000:cd30:0000:0000:0000:0008/126', 'Got expected v6 address');
+
+ok($config->secondary_prefix('s3', 'ipv4') eq '192.168.101.4/30', 'Got expected v4 address');
+ok($config->secondary_prefix('s3', 'ipv6') eq '3ffe:ffff:0000:cd30:0000:0000:0000:000c/126', 'Got expected v6 address');
+
+ok($config->secondary_prefix('s3', 'ipv4') eq '192.168.101.4/30', 'Got expected v4 address');
+ok($config->secondary_prefix('s3', 'ipv6') eq '3ffe:ffff:0000:cd30:0000:0000:0000:000c/126', 'Got expected v6 address');


### PR DESCRIPTION
The key to this change lies in the AzurePeeringConfig object. This
object is responsible for generation of the prefixes sent to Azure
upon provisioning.

Prefix selection starts with 192.168.100.248/30 for IPv4 and
3FFE:FFFF:0:CD30::0/126 for IPv6. The first Azure Endpoint will use
these prefixes. Every Endpoint after that will use the following
prefixes. For example, the 2nd Endpoint will use 192.168.100.252/30
and 3FFE:FFFF:0:CD30::4/126. The 3rd Endpoint will use
192.168.101.0/30 and 3FFE:FFFF:0:CD30::8/126.

As provisioning with IPv6 using the API is disabled, we also have
disabled IPv6 address selection. To use an IPv6 peering, it must be
set via the Azure Portal by the Customer.

Fixes #1142