### PR TITLE
1415 move_interface_configuration handles nso controlled devices

### DIFF
--- a/frontend/webservice/admin/admin.cgi
+++ b/frontend/webservice/admin/admin.cgi
@@ -1814,7 +1814,7 @@ sub move_interface_configuration {
     }
 
     my $mq = OESS::RabbitMQ::Client->new(
-        topic    => 'MPLS.FWDCTL.RPC',
+        topic    => $topic,
         timeout  => 60
     );
     if (!defined $mq) {


### PR DESCRIPTION
Resolves #1415. move_interface_configuration now handles iso controlled devices when interfaces are migrated on the old admin ui